### PR TITLE
Issue #89: Add preload="none" to video/audio elements

### DIFF
--- a/web/modules/custom/videojs_media/components/player/player.twig
+++ b/web/modules/custom/videojs_media/components/player/player.twig
@@ -5,7 +5,7 @@
 #}
 {% set is_audio = bundle in ['videojs_local_audio', 'videojs_remote_audio'] %}
 
-<{{ is_audio ? 'audio' : 'video' }} id="videojs-player-{{ random() }}" class="video-js" playsinline webkit-playsinline
+<{{ is_audio ? 'audio' : 'video' }} id="videojs-player-{{ random() }}" class="video-js" preload="none" playsinline webkit-playsinline
        {% if field_poster_image %}
          {% if field_poster_image[0]['#item'] %}
            {% set poster_uri = field_poster_image[0]['#item'].entity.uri.value %}

--- a/web/modules/custom/videojs_media/tests/src/Functional/PreloadNonePageTest.php
+++ b/web/modules/custom/videojs_media/tests/src/Functional/PreloadNonePageTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\videojs_media\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\videojs_media\Entity\VideoJsMedia;
+
+/**
+ * Tests that rendered pages include preload="none" on video elements.
+ *
+ * @group videojs_media
+ */
+class PreloadNonePageTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'node',
+    'taxonomy',
+    'views',
+    'videojs_media',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $viewUser = $this->drupalCreateUser([
+      'view local_video videojs media',
+      'view youtube videojs media',
+      'view remote_video videojs media',
+      'access content',
+    ]);
+    $this->drupalLogin($viewUser);
+  }
+
+  /**
+   * Tests that a local video entity page renders preload="none".
+   */
+  public function testLocalVideoPageHasPreloadNone(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_local_video',
+      'name' => 'Preload Test Video',
+      'status' => TRUE,
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->responseContains('preload="none"');
+  }
+
+  /**
+   * Tests that a YouTube entity page renders preload="none".
+   */
+  public function testYoutubePageHasPreloadNone(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_youtube',
+      'name' => 'Preload Test YouTube',
+      'status' => TRUE,
+      'field_youtube_url' => [
+        'uri' => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      ],
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->responseContains('preload="none"');
+  }
+
+  /**
+   * Tests that a remote video entity page renders preload="none".
+   */
+  public function testRemoteVideoPageHasPreloadNone(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_remote_video',
+      'name' => 'Preload Test Remote',
+      'status' => TRUE,
+      'field_remote_url' => [
+        'uri' => 'https://example.com/video.mp4',
+      ],
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->responseContains('preload="none"');
+  }
+
+}

--- a/web/modules/custom/videojs_media/tests/src/Kernel/PreloadAttributeTest.php
+++ b/web/modules/custom/videojs_media/tests/src/Kernel/PreloadAttributeTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\videojs_media\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests that the player template renders preload="none" on media elements.
+ *
+ * @group videojs_media
+ */
+class PreloadAttributeTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'file',
+    'text',
+    'link',
+    'image',
+    'taxonomy',
+    'videojs_media',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('videojs_media');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installConfig(['field', 'file', 'videojs_media']);
+    $this->installSchema('file', ['file_usage']);
+  }
+
+  /**
+   * Tests that the video element renders with preload="none".
+   */
+  public function testVideoElementHasPreloadNone(): void {
+    $build = [
+      '#type' => 'component',
+      '#component' => 'videojs_media:player',
+      '#props' => [
+        'entity_type' => 'videojs_media',
+        'bundle' => 'videojs_local_video',
+        'field_media_file' => [],
+        'field_remote_url' => [],
+        'field_youtube_url' => [],
+        'field_poster_image' => [],
+        'field_subtitle' => [],
+        'enable_viewport_monitoring' => FALSE,
+      ],
+    ];
+
+    $rendered = (string) \Drupal::service('renderer')->renderRoot($build);
+
+    $this->assertStringContainsString('preload="none"', $rendered, 'Video element must have preload="none".');
+    $this->assertStringContainsString('<video', $rendered, 'A <video> element must be rendered for video bundles.');
+  }
+
+  /**
+   * Tests that the audio element also renders with preload="none".
+   */
+  public function testAudioElementHasPreloadNone(): void {
+    $build = [
+      '#type' => 'component',
+      '#component' => 'videojs_media:player',
+      '#props' => [
+        'entity_type' => 'videojs_media',
+        'bundle' => 'videojs_local_audio',
+        'field_media_file' => [],
+        'field_remote_url' => [],
+        'field_youtube_url' => [],
+        'field_poster_image' => [],
+        'field_subtitle' => [],
+        'enable_viewport_monitoring' => FALSE,
+      ],
+    ];
+
+    $rendered = (string) \Drupal::service('renderer')->renderRoot($build);
+
+    $this->assertStringContainsString('preload="none"', $rendered, 'Audio element must have preload="none".');
+    $this->assertStringContainsString('<audio', $rendered, 'An <audio> element must be rendered for audio bundles.');
+  }
+
+}


### PR DESCRIPTION
Closes #89\n\n## Changes\n- Added `preload="none"` to the `<video>`/`<audio>` element in `player.twig`\n- Added Kernel test `PreloadAttributeTest` (passes 2/2)\n- Added Functional test `PreloadNonePageTest` (blocked by pre-existing `node_make_sticky_action` issue affecting all Functional tests in this module)\n\n## Testing\n- `ddev phpunit web/modules/custom/videojs_media/tests/src/Kernel/PreloadAttributeTest.php` — ✅ 2/2 pass\n- PHPCS clean