### PR TITLE
Issue #85: Eliminate duplicate VideoJS player initialization (remove data-setup)

### DIFF
--- a/web/modules/custom/videojs_media/components/player/player.js
+++ b/web/modules/custom/videojs_media/components/player/player.js
@@ -425,9 +425,17 @@
       once('videojs-elements', 'video.video-js, audio.video-js', context).forEach(
         function initializeVideoElement(videoElement) {
           try {
+            // Determine if this is an audio-only element
+            const isAudio = videoElement.hasAttribute('data-videojs-audio');
             // Initialize VideoJS on the element
             window.videojs(videoElement, {
               // phpcs:disable Generic.PHP.UpperCaseConstant
+              techOrder: ['html5', 'videojs_youtube'],
+              controls: true,
+              fluid: !isAudio,
+              videojs_youtube: {
+                playsinline: 1,
+              },
               html5: {
                 vhs: {
                   overrideNative: !window.videojs.browser.IS_SAFARI,

--- a/web/modules/custom/videojs_media/components/player/player.twig
+++ b/web/modules/custom/videojs_media/components/player/player.twig
@@ -16,7 +16,7 @@
          {% endif %}
        {% endif %}
        {% if enable_viewport_monitoring %}data-enable-viewport-monitoring="true"{% endif %}
-       data-setup='{"techOrder": ["html5", "videojs_youtube"], {{ is_audio ? "" : "\"fluid\": true, " }}"controls": true, "videojs_youtube": {"playsinline": 1}, "html5": {"vhs": {"overrideNative": true}}}'>
+       {% if is_audio %}data-videojs-audio="true"{% endif %}>
 
   {# Local media file (audio or video) #}
   {% if field_media_file %}

--- a/web/modules/custom/videojs_media/tests/src/Functional/SingleInitializationTest.php
+++ b/web/modules/custom/videojs_media/tests/src/Functional/SingleInitializationTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\videojs_media\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\videojs_media\Entity\VideoJsMedia;
+
+/**
+ * Tests that rendered player pages do not contain a data-setup attribute.
+ *
+ * Ensures the Drupal behavior is the single VideoJS initialization path —
+ * no data-setup attribute means Video.js auto-init is disabled and only
+ * the JS behavior initializes the player.
+ *
+ * @group videojs_media
+ */
+class SingleInitializationTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'node',
+    'taxonomy',
+    'views',
+    'videojs_media',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $viewUser = $this->drupalCreateUser([
+      'view local_video videojs media',
+      'view youtube videojs media',
+      'view remote_video videojs media',
+      'access content',
+    ]);
+    $this->drupalLogin($viewUser);
+  }
+
+  /**
+   * Tests that a local video page does not contain data-setup.
+   */
+  public function testLocalVideoPageHasNoDataSetup(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_local_video',
+      'name' => 'Single Init Test Video',
+      'status' => TRUE,
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->responseNotContains('data-setup');
+    $this->assertSession()->responseContains('class="video-js"');
+  }
+
+  /**
+   * Tests that a YouTube entity page does not contain data-setup.
+   */
+  public function testYoutubePageHasNoDataSetup(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_youtube',
+      'name' => 'Single Init Test YouTube',
+      'status' => TRUE,
+      'field_youtube_url' => [
+        'uri' => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      ],
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->responseNotContains('data-setup');
+    $this->assertSession()->responseContains('class="video-js"');
+  }
+
+  /**
+   * Tests that a remote video page does not contain data-setup.
+   */
+  public function testRemoteVideoPageHasNoDataSetup(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_remote_video',
+      'name' => 'Single Init Test Remote',
+      'status' => TRUE,
+      'field_remote_url' => [
+        'uri' => 'https://example.com/video.mp4',
+      ],
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->responseNotContains('data-setup');
+    $this->assertSession()->responseContains('class="video-js"');
+  }
+
+}

--- a/web/modules/custom/videojs_media/tests/src/Kernel/PlayerTemplateTest.php
+++ b/web/modules/custom/videojs_media/tests/src/Kernel/PlayerTemplateTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\videojs_media\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests that the player template does not render a data-setup attribute.
+ *
+ * @group videojs_media
+ */
+class PlayerTemplateTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'file',
+    'text',
+    'link',
+    'image',
+    'taxonomy',
+    'videojs_media',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('videojs_media');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installConfig(['field', 'file', 'videojs_media']);
+    $this->installSchema('file', ['file_usage']);
+  }
+
+  /**
+   * Tests that the video element does not contain a data-setup attribute.
+   */
+  public function testVideoElementHasNoDataSetup(): void {
+    $build = [
+      '#type' => 'component',
+      '#component' => 'videojs_media:player',
+      '#props' => [
+        'entity_type' => 'videojs_media',
+        'bundle' => 'videojs_local_video',
+        'field_media_file' => [],
+        'field_remote_url' => [],
+        'field_youtube_url' => [],
+        'field_poster_image' => [],
+        'field_subtitle' => [],
+        'enable_viewport_monitoring' => FALSE,
+      ],
+    ];
+
+    $rendered = (string) \Drupal::service('renderer')->renderRoot($build);
+
+    $this->assertStringNotContainsString('data-setup', $rendered, 'Video element must not have a data-setup attribute.');
+    $this->assertStringContainsString('class="video-js"', $rendered, 'Video element must have class="video-js".');
+    $this->assertStringContainsString('<video', $rendered, 'A <video> element must be rendered for video bundles.');
+  }
+
+  /**
+   * Tests that the audio element does not contain a data-setup attribute.
+   */
+  public function testAudioElementHasNoDataSetup(): void {
+    $build = [
+      '#type' => 'component',
+      '#component' => 'videojs_media:player',
+      '#props' => [
+        'entity_type' => 'videojs_media',
+        'bundle' => 'videojs_local_audio',
+        'field_media_file' => [],
+        'field_remote_url' => [],
+        'field_youtube_url' => [],
+        'field_poster_image' => [],
+        'field_subtitle' => [],
+        'enable_viewport_monitoring' => FALSE,
+      ],
+    ];
+
+    $rendered = (string) \Drupal::service('renderer')->renderRoot($build);
+
+    $this->assertStringNotContainsString('data-setup', $rendered, 'Audio element must not have a data-setup attribute.');
+    $this->assertStringContainsString('class="video-js"', $rendered, 'Audio element must have class="video-js".');
+    $this->assertStringContainsString('<audio', $rendered, 'An <audio> element must be rendered for audio bundles.');
+  }
+
+  /**
+   * Tests that the audio element has the data-videojs-audio attribute.
+   */
+  public function testAudioElementHasAudioDataAttribute(): void {
+    $build = [
+      '#type' => 'component',
+      '#component' => 'videojs_media:player',
+      '#props' => [
+        'entity_type' => 'videojs_media',
+        'bundle' => 'videojs_local_audio',
+        'field_media_file' => [],
+        'field_remote_url' => [],
+        'field_youtube_url' => [],
+        'field_poster_image' => [],
+        'field_subtitle' => [],
+        'enable_viewport_monitoring' => FALSE,
+      ],
+    ];
+
+    $rendered = (string) \Drupal::service('renderer')->renderRoot($build);
+
+    $this->assertStringContainsString(
+      'data-videojs-audio="true"',
+      $rendered,
+      'Audio element must have data-videojs-audio="true" for JS fluid detection.',
+    );
+  }
+
+  /**
+   * Tests that the video element does not have the data-videojs-audio attr.
+   */
+  public function testVideoElementHasNoAudioDataAttribute(): void {
+    $build = [
+      '#type' => 'component',
+      '#component' => 'videojs_media:player',
+      '#props' => [
+        'entity_type' => 'videojs_media',
+        'bundle' => 'videojs_local_video',
+        'field_media_file' => [],
+        'field_remote_url' => [],
+        'field_youtube_url' => [],
+        'field_poster_image' => [],
+        'field_subtitle' => [],
+        'enable_viewport_monitoring' => FALSE,
+      ],
+    ];
+
+    $rendered = (string) \Drupal::service('renderer')->renderRoot($build);
+
+    $this->assertStringNotContainsString('data-videojs-audio', $rendered, 'Video element must not have data-videojs-audio attribute.');
+  }
+
+}


### PR DESCRIPTION
Closes #85

## Changes

- Removed `data-setup` from `player.twig` — disables Video.js auto-init so the Drupal behavior is the single init path.
- Added `data-videojs-audio="true"` on audio elements so JS can detect audio bundles and skip `fluid` mode.
- Moved `techOrder`, `controls`, `fluid`, and `videojs_youtube` options into the `window.videojs()` call in `player.js`.

## Tests

- **Kernel:** `PlayerTemplateTest` — asserts no `data-setup` in rendered HTML, correct element types, and `data-videojs-audio` presence/absence.
- **Functional:** `SingleInitializationTest` — asserts no `data-setup` on rendered entity pages for local video, YouTube, and remote video bundles.
- All 4 Kernel tests pass. Functional tests fail with a pre-existing `node_make_sticky_action` plugin error affecting the entire functional suite (unrelated to this issue).
