### PR TITLE
Issue #84: Conditionally load @videojs/http-streaming only for adaptive streams

### DIFF
--- a/web/modules/custom/videojs_media/tests/src/Functional/PlayerWithoutVhsTest.php
+++ b/web/modules/custom/videojs_media/tests/src/Functional/PlayerWithoutVhsTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\videojs_media\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\videojs_media\Entity\VideoJsMedia;
+
+/**
+ * Tests that the VHS script is only loaded for adaptive stream sources.
+ *
+ * Verifies that MP4/YouTube pages do not include the http-streaming script,
+ * and that HLS sources do include it.
+ *
+ * @group videojs_media
+ */
+class PlayerWithoutVhsTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'node',
+    'taxonomy',
+    'views',
+    'videojs_media',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $viewUser = $this->drupalCreateUser([
+      'view local_video videojs media',
+      'view youtube videojs media',
+      'view remote_video videojs media',
+      'access content',
+    ]);
+    $this->drupalLogin($viewUser);
+  }
+
+  /**
+   * Tests that an MP4 video page does not load the http-streaming script.
+   */
+  public function testMp4PageDoesNotLoadVhs(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_local_video',
+      'name' => 'MP4 No VHS Test',
+      'status' => TRUE,
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->responseNotContains('videojs-http-streaming');
+  }
+
+  /**
+   * Tests that a YouTube video page does not load the http-streaming script.
+   */
+  public function testYoutubePageDoesNotLoadVhs(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_youtube',
+      'name' => 'YouTube No VHS Test',
+      'status' => TRUE,
+      'field_youtube_url' => [
+        'uri' => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      ],
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->responseNotContains('videojs-http-streaming');
+  }
+
+  /**
+   * Tests that a remote HLS source page DOES load the http-streaming script.
+   */
+  public function testHlsPageLoadsVhs(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_remote_video',
+      'name' => 'HLS VHS Test',
+      'status' => TRUE,
+      'field_remote_url' => [
+        'value' => 'https://example.com/stream/playlist.m3u8',
+      ],
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->responseContains('videojs-http-streaming');
+  }
+
+}

--- a/web/modules/custom/videojs_media/tests/src/Kernel/ConditionalVhsLibraryTest.php
+++ b/web/modules/custom/videojs_media/tests/src/Kernel/ConditionalVhsLibraryTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\videojs_media\Kernel;
+
+use Drupal\Core\Entity\Entity\EntityViewDisplay;
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\videojs_media\Entity\VideoJsMedia;
+
+/**
+ * Tests that the HLS library is attached only for adaptive stream sources.
+ *
+ * @group videojs_media
+ */
+class ConditionalVhsLibraryTest extends EntityKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'videojs_media',
+    'file',
+    'image',
+    'options',
+    'file_upload_secure_validator',
+    'link',
+    'taxonomy',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('videojs_media');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installSchema('file', ['file_usage']);
+    $this->installConfig(['videojs_media']);
+  }
+
+  /**
+   * Creates a minimal EntityViewDisplay for the given bundle.
+   */
+  protected function createDisplay(string $bundle): EntityViewDisplay {
+    return EntityViewDisplay::create([
+      'targetEntityType' => 'videojs_media',
+      'bundle' => $bundle,
+      'mode' => 'default',
+      'status' => TRUE,
+    ]);
+  }
+
+  /**
+   * Invokes the hook and returns the libraries attached to $build.
+   */
+  protected function getAttachedLibraries(VideoJsMedia $entity): array {
+    $build = [];
+    $display = $this->createDisplay($entity->bundle());
+    videojs_media_videojs_media_view($build, $entity, $display, 'default');
+    return $build['#attached']['library'] ?? [];
+  }
+
+  /**
+   * Tests that an MP4 local video does NOT attach the HLS library.
+   */
+  public function testMp4DoesNotAttachHlsLibrary(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_local_video',
+      'name' => 'MP4 Test',
+      'status' => TRUE,
+    ]);
+    $entity->save();
+
+    $libraries = $this->getAttachedLibraries($entity);
+    $this->assertNotContains('videojs_media/videojs-player-hls', $libraries,
+      'MP4 source must not attach the HLS library.');
+  }
+
+  /**
+   * Tests that a YouTube entity does NOT attach the HLS library.
+   */
+  public function testYoutubeDoesNotAttachHlsLibrary(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_youtube',
+      'name' => 'YouTube Test',
+      'status' => TRUE,
+      'field_youtube_url' => [
+        'uri' => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      ],
+    ]);
+    $entity->save();
+
+    $libraries = $this->getAttachedLibraries($entity);
+    $this->assertNotContains('videojs_media/videojs-player-hls', $libraries,
+      'YouTube source must not attach the HLS library.');
+  }
+
+  /**
+   * Tests that a remote HLS (.m3u8) source DOES attach the HLS library.
+   */
+  public function testRemoteHlsAttachesHlsLibrary(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_remote_video',
+      'name' => 'HLS Remote Test',
+      'status' => TRUE,
+      'field_remote_url' => [
+        'value' => 'https://example.com/stream/playlist.m3u8',
+      ],
+    ]);
+    $entity->save();
+
+    $libraries = $this->getAttachedLibraries($entity);
+    $this->assertContains('videojs_media/videojs-player-hls', $libraries,
+      'Remote HLS (.m3u8) source must attach the HLS library.');
+  }
+
+  /**
+   * Tests that a remote DASH (.mpd) source DOES attach the HLS library.
+   */
+  public function testRemoteDashAttachesHlsLibrary(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_remote_video',
+      'name' => 'DASH Remote Test',
+      'status' => TRUE,
+      'field_remote_url' => [
+        'value' => 'https://example.com/stream/manifest.mpd',
+      ],
+    ]);
+    $entity->save();
+
+    $libraries = $this->getAttachedLibraries($entity);
+    $this->assertContains('videojs_media/videojs-player-hls', $libraries,
+      'Remote DASH (.mpd) source must attach the HLS library.');
+  }
+
+}

--- a/web/modules/custom/videojs_media/videojs_media.libraries.yml
+++ b/web/modules/custom/videojs_media/videojs_media.libraries.yml
@@ -6,10 +6,16 @@ videojs-player:
       node_modules/videojs-mobile-ui/dist/videojs-mobile-ui.css: {}
   js:
     node_modules/video.js/dist/video.js: {}
-    node_modules/@videojs/http-streaming/dist/videojs-http-streaming.js: {}
     node_modules/videojs-youtube/dist/Youtube.js: {}
     node_modules/videojs-hotkeys/videojs.hotkeys.min.js: {}
     node_modules/videojs-mobile-ui/dist/videojs-mobile-ui.js: {}
   dependencies:
     - core/drupal
     - core/once
+
+videojs-player-hls:
+  version: VERSION
+  js:
+    node_modules/@videojs/http-streaming/dist/videojs-http-streaming.js: {}
+  dependencies:
+    - videojs_media/videojs-player

--- a/web/modules/custom/videojs_media/videojs_media.module
+++ b/web/modules/custom/videojs_media/videojs_media.module
@@ -117,25 +117,35 @@ function videojs_media_theme_suggestions_videojs_media(array $variables) {
  * Implements hook_ENTITY_TYPE_view().
  */
 function videojs_media_videojs_media_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
-  // Add any preprocessing specific to viewing the entity.
-  // This is where you could add custom logic based on bundle type.
+  // Conditionally attach the HLS/DASH library only for adaptive stream sources.
   $bundle = $entity->bundle();
+  $hls_extensions = ['m3u8', 'mpd'];
+  $needs_hls = FALSE;
 
-  // Add bundle-specific preprocessing if needed.
-  switch ($bundle) {
-    case 'videojs_youtube':
-      // YouTube-specific preprocessing.
-      break;
+  if (in_array($bundle, ['videojs_local_video', 'videojs_local_audio'], TRUE)) {
+    if ($entity->hasField('field_media_file') && !$entity->get('field_media_file')->isEmpty()) {
+      $file = $entity->get('field_media_file')->entity;
+      if ($file) {
+        $uri = $file->getFileUri();
+        $ext = strtolower(pathinfo($uri, PATHINFO_EXTENSION));
+        $needs_hls = in_array($ext, $hls_extensions, TRUE);
+      }
+    }
+  }
+  elseif (in_array($bundle, ['videojs_remote_video', 'videojs_remote_audio'], TRUE)) {
+    if ($entity->hasField('field_remote_url') && !$entity->get('field_remote_url')->isEmpty()) {
+      $url = $entity->get('field_remote_url')->value;
+      if ($url) {
+        $path = parse_url($url, PHP_URL_PATH) ?? '';
+        $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+        $needs_hls = in_array($ext, $hls_extensions, TRUE);
+      }
+    }
+  }
+  // YouTube never needs HLS.
 
-    case 'videojs_local_video':
-    case 'videojs_local_audio':
-      // Local media preprocessing.
-      break;
-
-    case 'videojs_remote_video':
-    case 'videojs_remote_audio':
-      // Remote media preprocessing.
-      break;
+  if ($needs_hls) {
+    $build['#attached']['library'][] = 'videojs_media/videojs-player-hls';
   }
 }
 


### PR DESCRIPTION
Closes #84

Splits videojs-player library into base + videojs-player-hls add-on. Removes http-streaming from base; attaches only for HLS/DASH (.m3u8/.mpd) sources via hook_ENTITY_TYPE_view(). YouTube and MP4 never load VHS. Kernel test ConditionalVhsLibraryTest (4 passing) and Functional test PlayerWithoutVhsTest added.