### PR TITLE
Issue #87: Lazy-initialize VideoJS players — defer until visible or modal open

### DIFF
--- a/web/modules/custom/videojs_media/components/player/player.js
+++ b/web/modules/custom/videojs_media/components/player/player.js
@@ -426,76 +426,202 @@
   };
 
   /**
-   * Helper to initialize VideoJS players with SDC components.
+   * Lazy-initialize VideoJS players with SDC components.
+   *
+   * Page players: deferred via IntersectionObserver until the facade enters
+   * the viewport. Modal players: deferred until the Bootstrap modal fires
+   * `show.bs.modal`, then disposed when `hide.bs.modal` fires.
    *
    * @type {Drupal~behavior}
    */
   Drupal.behaviors.videojsMediablockPlayerInit = {
-    attach(context) {
-      // Only initialize if videojs is available
+
+    /**
+     * Initializes a single VideoJS player from a facade wrapper element.
+     *
+     * Hides the facade overlay, shows the video element, calls window.videojs(),
+     * and optionally starts playback.
+     *
+     * @param {HTMLElement} facadeEl - The `.videojs-lazy-facade` wrapper element.
+     * @param {boolean} autoplay - Whether to start playback after init.
+     */
+    initPlayerFromFacade(facadeEl, autoplay) {
+      if (facadeEl.hasAttribute('data-videojs-facade-initialized')) {
+        // Already initialized — just play if requested.
+        const videoEl = facadeEl.querySelector('.videojs-lazy-target');
+        if (autoplay && videoEl && videoEl.player && !videoEl.player.isDisposed()) {
+          videoEl.player.play();
+        }
+        return;
+      }
+      facadeEl.setAttribute('data-videojs-facade-initialized', 'true');
+
       if (typeof window.videojs === 'undefined') {
         return;
       }
 
-      once('videojs-elements', 'video.video-js, audio.video-js', context).forEach(
-        function initializeVideoElement(videoElement) {
+      const videoEl = facadeEl.querySelector('.videojs-lazy-target');
+      if (!videoEl) {
+        return;
+      }
+
+      // Hide facade overlays (poster img + play button) — keep the video element.
+      const poster = facadeEl.querySelector('.videojs-lazy-facade__poster');
+      const playBtn = facadeEl.querySelector('.videojs-lazy-facade__play-btn');
+      if (poster) {
+        poster.style.display = 'none';
+      }
+      if (playBtn) {
+        playBtn.style.display = 'none';
+      }
+
+      try {
+        const isAudio = videoEl.hasAttribute('data-videojs-audio');
+        // phpcs:disable Generic.PHP.UpperCaseConstant
+        window.videojs(videoEl, {
+          techOrder: ['html5', 'videojs_youtube'],
+          controls: true,
+          fluid: !isAudio,
+          autoplay: autoplay ? 'any' : false,
+          videojs_youtube: {
+            playsinline: 1,
+          },
+          html5: {
+            vhs: {
+              overrideNative: !window.videojs.browser.IS_SAFARI,
+              enableLowInitialPlaylist: true,
+              smoothQualityChange: true,
+              useBandwidthFromLocalStorage: true,
+            },
+          },
+        // phpcs:enable Generic.PHP.UpperCaseConstant
+        }, function videojsReadyCallback() {
+          this.el().setAttribute('data-videojs-initialized', 'true');
+
+          // Configure adaptive bitrate settings if HLS/DASH source is detected.
+          const sources = this.currentSources();
+          const hasAdaptiveStream = sources.some(source =>
+            source.type === 'application/vnd.apple.mpegurl' ||
+            source.type === 'application/dash+xml',
+          );
+
+          if (hasAdaptiveStream && this.qualityLevels) {
+            this.qualityLevels().on('addqualitylevel', (event) => {
+              console.log('Quality level added:', event.qualityLevel);
+            });
+          }
+
+          // Notify other behaviors that a player is ready.
           try {
-            // Determine if this is an audio-only element
-            const isAudio = videoElement.hasAttribute('data-videojs-audio');
-            // Initialize VideoJS on the element
-            window.videojs(videoElement, {
-              // phpcs:disable Generic.PHP.UpperCaseConstant
-              techOrder: ['html5', 'videojs_youtube'],
-              controls: true,
-              fluid: !isAudio,
-              videojs_youtube: {
-                playsinline: 1,
-              },
-              html5: {
-                vhs: {
-                  overrideNative: !window.videojs.browser.IS_SAFARI,
-                  enableLowInitialPlaylist: true,
-                  smoothQualityChange: true,
-                  useBandwidthFromLocalStorage: true,
-                },
-              },
-              // phpcs:enable Generic.PHP.UpperCaseConstant
-            }, function videojsReadyCallback() {
-              // Player is ready
-              this.el().setAttribute('data-videojs-initialized', 'true');
+            document.dispatchEvent(new CustomEvent('videojs-player-ready', {
+              detail: this,
+            }));
+          } catch (err) {
+            console.error('Error dispatching videojs-player-ready event:', err);
+          }
+        });
+      } catch (e) {
+        console.error('Error initializing VideoJS player:', e);
+      }
+    },
 
-              // Configure adaptive bitrate settings if HLS/DASH source is detected
-              const sources = this.currentSources();
-              const hasAdaptiveStream = sources.some(source =>
-                source.type === 'application/vnd.apple.mpegurl' ||
-                source.type === 'application/dash+xml',
-              );
+    /**
+     * Disposes the VideoJS player inside a facade wrapper, if one exists.
+     *
+     * Restores the facade overlays so the element can be re-initialized later.
+     *
+     * @param {HTMLElement} facadeEl - The `.videojs-lazy-facade` wrapper element.
+     */
+    disposePlayerInFacade(facadeEl) {
+      const videoEl = facadeEl.querySelector('.videojs-lazy-target');
+      if (videoEl && videoEl.player && !videoEl.player.isDisposed()) {
+        videoEl.player.dispose();
+      }
+      facadeEl.removeAttribute('data-videojs-facade-initialized');
 
-              if (hasAdaptiveStream) {
-                // Enable quality menu if available
-                if (this.qualityLevels) {
-                  this.qualityLevels().on('addqualitylevel', (event) => {
-                    console.log('Quality level added:', event.qualityLevel);
-                  });
-                }
-              }
+      // Restore facade overlays.
+      const poster = facadeEl.querySelector('.videojs-lazy-facade__poster');
+      const playBtn = facadeEl.querySelector('.videojs-lazy-facade__play-btn');
+      if (poster) {
+        poster.style.display = '';
+      }
+      if (playBtn) {
+        playBtn.style.display = '';
+      }
+    },
 
-              // Trigger a native event (no jQuery dependency)
-              try {
-                const event = new CustomEvent('videojs-player-ready', {
-                  detail: this,
-                });
-                document.dispatchEvent(event);
-              } catch (err) {
-                console.error(
-                  'Error dispatching videojs-player-ready event:',
-                  err,
-                );
+    attach(context) {
+      const self = this;
+
+      // ── Facade play-button click / keyboard activation ──────────────────────
+      once('videojs-facade-click', '.videojs-lazy-facade', context).forEach(
+        function attachFacadeInteraction(facadeEl) {
+          const playBtn = facadeEl.querySelector('.videojs-lazy-facade__play-btn');
+          if (playBtn) {
+            playBtn.addEventListener('click', function onPlayBtnClick() {
+              self.initPlayerFromFacade(facadeEl, true);
+            });
+            playBtn.addEventListener('keydown', function onPlayBtnKeydown(e) {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                self.initPlayerFromFacade(facadeEl, true);
               }
             });
-          } catch (e) {
-            console.error('Error initializing VideoJS player:', e);
           }
+        },
+      );
+
+      // ── Page players: IntersectionObserver lazy init ─────────────────────────
+      // Only for facades NOT inside a Bootstrap modal.
+      once('videojs-lazy-page', '.videojs-lazy-facade', context).forEach(
+        function observePagePlayer(facadeEl) {
+          // Skip modal players — handled separately below.
+          if (facadeEl.closest('.modal')) {
+            return;
+          }
+
+          if (!('IntersectionObserver' in window)) {
+            // Fallback: initialize immediately.
+            self.initPlayerFromFacade(facadeEl, false);
+            return;
+          }
+
+          const observer = new IntersectionObserver(
+            function intersectionCallback(entries, obs) {
+              entries.forEach(function handleEntry(entry) {
+                if (entry.isIntersecting) {
+                  self.initPlayerFromFacade(facadeEl, false);
+                  obs.unobserve(facadeEl);
+                }
+              });
+            },
+            // phpcs:disable Generic.PHP.UpperCaseConstant
+            { rootMargin: '200px', threshold: 0 },
+            // phpcs:enable Generic.PHP.UpperCaseConstant
+          );
+
+          observer.observe(facadeEl);
+        },
+      );
+
+      // ── Modal players: init on show, dispose on hide ─────────────────────────
+      once('videojs-modal-players', '.modal', context).forEach(
+        function attachModalPlayerLifecycle(modalEl) {
+          modalEl.addEventListener('show.bs.modal', function onModalShow() {
+            modalEl.querySelectorAll('.videojs-lazy-facade').forEach(
+              function initModalPlayer(facadeEl) {
+                self.initPlayerFromFacade(facadeEl, false);
+              },
+            );
+          });
+
+          modalEl.addEventListener('hide.bs.modal', function onModalHide() {
+            modalEl.querySelectorAll('.videojs-lazy-facade').forEach(
+              function disposeModalPlayer(facadeEl) {
+                self.disposePlayerInFacade(facadeEl);
+              },
+            );
+          });
         },
       );
     },

--- a/web/modules/custom/videojs_media/components/player/player.twig
+++ b/web/modules/custom/videojs_media/components/player/player.twig
@@ -4,35 +4,94 @@
   Fields are passed as render arrays with their values.
 #}
 {% set is_audio = bundle in ['videojs_local_audio', 'videojs_remote_audio'] %}
+{% set player_id = 'videojs-player-' ~ random() %}
 
-<{{ is_audio ? 'audio' : 'video' }} id="videojs-player-{{ random() }}" class="video-js" preload="none" playsinline webkit-playsinline
-       {% if field_poster_image %}
-         {% if field_poster_image[0]['#item'] %}
-           {% set poster_uri = field_poster_image[0]['#item'].entity.uri.value %}
-           {% if poster_uri %}poster="{{ file_url(poster_uri) }}"{% endif %}
-         {% elseif field_poster_image['#items'] %}
-           {% set poster_uri = field_poster_image['#items'].entity.uri.value %}
-           {% if poster_uri %}poster="{{ file_url(poster_uri) }}"{% endif %}
-         {% endif %}
-       {% endif %}
-       {% if enable_viewport_monitoring %}data-enable-viewport-monitoring="true"{% endif %}
-       {% if is_audio %}data-videojs-audio="true"{% endif %}>
+{# Resolve poster URL for facade and video element #}
+{% set poster_url = null %}
+{% if field_poster_image %}
+  {% if field_poster_image[0]['#item'] %}
+    {% set poster_uri = field_poster_image[0]['#item'].entity.uri.value %}
+    {% if poster_uri %}{% set poster_url = file_url(poster_uri) %}{% endif %}
+  {% elseif field_poster_image['#items'] %}
+    {% set poster_uri = field_poster_image['#items'].entity.uri.value %}
+    {% if poster_uri %}{% set poster_url = file_url(poster_uri) %}{% endif %}
+  {% endif %}
+{% endif %}
 
-  {# Local media file (audio or video) #}
-  {% if field_media_file %}
-    {% set items = field_media_file['#items'] ?? field_media_file[0]['#item'] ?? null %}
-    {% if items %}
-      {% if items.entity %}
-        {% set file_uri = items.entity.uri.value %}
-      {% elseif items[0] and items[0].entity %}
-        {% set file_uri = items[0].entity.uri.value %}
+{# Facade wrapper — JS replaces this with the initialised player #}
+<div class="videojs-lazy-facade"
+     data-lazy-player="true"
+     {% if is_audio %}data-lazy-player-audio="true"{% endif %}
+     {% if enable_viewport_monitoring %}data-enable-viewport-monitoring="true"{% endif %}>
+
+  {# Static poster / thumbnail shown before player initialises #}
+  {% if poster_url and not is_audio %}
+    <img class="videojs-lazy-facade__poster"
+         src="{{ poster_url }}"
+         alt=""
+         aria-hidden="true">
+  {% endif %}
+
+  {# Accessible play button overlay #}
+  {% if not is_audio %}
+    <button class="videojs-lazy-facade__play-btn"
+            type="button"
+            role="button"
+            tabindex="0"
+            aria-label="{{ 'Play video'|t }}">
+      <span class="videojs-lazy-facade__play-icon" aria-hidden="true">&#9654;</span>
+    </button>
+  {% endif %}
+
+  {# Hidden video/audio element — initialised lazily by player.js #}
+  <{{ is_audio ? 'audio' : 'video' }} id="{{ player_id }}" class="video-js videojs-lazy-target" preload="none" playsinline webkit-playsinline
+         {% if poster_url %}poster="{{ poster_url }}"{% endif %}
+         {% if enable_viewport_monitoring %}data-enable-viewport-monitoring="true"{% endif %}
+         {% if is_audio %}data-videojs-audio="true"{% endif %}>
+    {# Local media file (audio or video) #}
+    {% if field_media_file %}
+      {% set items = field_media_file['#items'] ?? field_media_file[0]['#item'] ?? null %}
+      {% if items %}
+        {% if items.entity %}
+          {% set file_uri = items.entity.uri.value %}
+        {% elseif items[0] and items[0].entity %}
+          {% set file_uri = items[0].entity.uri.value %}
+        {% endif %}
+        {% if file_uri %}
+          {% set file_url_path = file_url(file_uri) %}
+          {% set file_extension = file_uri|split('.')|last|lower %}
+          {# Map file extensions to MIME types #}
+          {% set mime_types = {
+            'mp3': 'audio/mpeg',
+            'wav': 'audio/wav',
+            'ogg': 'audio/ogg',
+            'aac': 'audio/aac',
+            'm4a': 'audio/mp4',
+            'mp4': 'video/mp4',
+            'webm': 'video/webm',
+            'ogv': 'video/ogg',
+            'mov': 'video/quicktime',
+            'm3u8': 'application/vnd.apple.mpegurl',
+            'mpd': 'application/dash+xml'
+          } %}
+          <source
+            src="{{ file_url_path }}"
+            type="{{ mime_types[file_extension] ?? (is_audio ? 'audio/mpeg' : 'video/mp4') }}">
+        {% endif %}
       {% endif %}
-
-      {% if file_uri %}
-        {% set file_url_path = file_url(file_uri) %}
-        {% set file_extension = file_uri|split('.')|last|lower %}
-
-        {# Map file extensions to MIME types #}
+    {% endif %}
+    {# Remote URL (audio or video) #}
+    {% if field_remote_url %}
+      {% set remote_url = null %}
+      {% if field_remote_url[0]['#context'] %}
+        {% set remote_url = field_remote_url[0]['#context'].value %}
+      {% elseif field_remote_url[0]['#url'] %}
+        {% set remote_url = field_remote_url[0]['#url'].toString() %}
+      {% elseif field_remote_url['#items'] %}
+        {% set remote_url = field_remote_url['#items'][0].uri %}
+      {% endif %}
+      {% if remote_url %}
+        {% set file_extension = remote_url|split('.')|last|split('?')|first|lower %}
         {% set mime_types = {
           'mp3': 'audio/mpeg',
           'wav': 'audio/wav',
@@ -42,76 +101,37 @@
           'mp4': 'video/mp4',
           'webm': 'video/webm',
           'ogv': 'video/ogg',
-          'mov': 'video/quicktime',
           'm3u8': 'application/vnd.apple.mpegurl',
           'mpd': 'application/dash+xml'
         } %}
-
         <source
-          src="{{ file_url_path }}"
+          src="{{ remote_url }}"
           type="{{ mime_types[file_extension] ?? (is_audio ? 'audio/mpeg' : 'video/mp4') }}">
       {% endif %}
     {% endif %}
-  {% endif %}
-
-  {# Remote URL (audio or video) #}
-  {% if field_remote_url %}
-    {% set remote_url = null %}
-    {% if field_remote_url[0]['#context'] %}
-      {% set remote_url = field_remote_url[0]['#context'].value %}
-    {% elseif field_remote_url[0]['#url'] %}
-      {% set remote_url = field_remote_url[0]['#url'].toString() %}
-    {% elseif field_remote_url['#items'] %}
-      {% set remote_url = field_remote_url['#items'][0].uri %}
-    {% endif %}
-
-    {% if remote_url %}
-      {% set file_extension = remote_url|split('.')|last|split('?')|first|lower %}
-
-      {% set mime_types = {
-        'mp3': 'audio/mpeg',
-        'wav': 'audio/wav',
-        'ogg': 'audio/ogg',
-        'aac': 'audio/aac',
-        'm4a': 'audio/mp4',
-        'mp4': 'video/mp4',
-        'webm': 'video/webm',
-        'ogv': 'video/ogg',
-        'm3u8': 'application/vnd.apple.mpegurl',
-        'mpd': 'application/dash+xml'
-      } %}
-
-      <source
-        src="{{ remote_url }}"
-        type="{{ mime_types[file_extension] ?? (is_audio ? 'audio/mpeg' : 'video/mp4') }}">
-    {% endif %}
-  {% endif %}
-
-  {# YouTube #}
-  {% if field_youtube_url %}
-    {% if field_youtube_url[0]['#context'] %}
-      <source src="{{ field_youtube_url[0]['#context'].value }}"
-              type="video/youtube">
-    {% endif %}
-  {% endif %}
-
-  {# Closed-captions, subtitles #}
-  {% if field_subtitle %}
-    {% set subtitle_items = field_subtitle['#items'] ?? field_subtitle[0]['#item'] ?? null %}
-    {% if subtitle_items %}
-      {% set subtitle_uri = null %}
-      {% if subtitle_items.entity %}
-        {% set subtitle_uri = subtitle_items.entity.uri.value %}
-      {% elseif subtitle_items[0] and subtitle_items[0].entity %}
-        {% set subtitle_uri = subtitle_items[0].entity.uri.value %}
-      {% endif %}
-
-      {% if subtitle_uri %}
-        <track kind="captions"
-               src="{{ file_url(subtitle_uri) }}"
-               srclang="en" label="English" default>
+    {# YouTube #}
+    {% if field_youtube_url %}
+      {% if field_youtube_url[0]['#context'] %}
+        <source src="{{ field_youtube_url[0]['#context'].value }}"
+                type="video/youtube">
       {% endif %}
     {% endif %}
-  {% endif %}
-
-</{{ is_audio ? 'audio' : 'video' }}>
+    {# Closed-captions, subtitles #}
+    {% if field_subtitle %}
+      {% set subtitle_items = field_subtitle['#items'] ?? field_subtitle[0]['#item'] ?? null %}
+      {% if subtitle_items %}
+        {% set subtitle_uri = null %}
+        {% if subtitle_items.entity %}
+          {% set subtitle_uri = subtitle_items.entity.uri.value %}
+        {% elseif subtitle_items[0] and subtitle_items[0].entity %}
+          {% set subtitle_uri = subtitle_items[0].entity.uri.value %}
+        {% endif %}
+        {% if subtitle_uri %}
+          <track kind="captions"
+                 src="{{ file_url(subtitle_uri) }}"
+                 srclang="en" label="English" default>
+        {% endif %}
+      {% endif %}
+    {% endif %}
+  </{{ is_audio ? 'audio' : 'video' }}>
+</div>

--- a/web/modules/custom/videojs_media/tests/src/Functional/LazyInitializationTest.php
+++ b/web/modules/custom/videojs_media/tests/src/Functional/LazyInitializationTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\videojs_media\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\videojs_media\Entity\VideoJsMedia;
+
+/**
+ * Tests that VideoJS players are not eagerly initialized on page load.
+ *
+ * Verifies that the lazy-init facade is rendered on archive listing pages
+ * and that no data-videojs-initialized attribute is present on initial load,
+ * confirming zero VideoJS instances are created before user interaction.
+ *
+ * @group videojs_media
+ */
+class LazyInitializationTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'node',
+    'taxonomy',
+    'views',
+    'videojs_media',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $viewUser = $this->drupalCreateUser([
+      'view local_video videojs media',
+      'view youtube videojs media',
+      'view remote_video videojs media',
+      'access content',
+    ]);
+    $this->drupalLogin($viewUser);
+  }
+
+  /**
+   * Tests that a local video page renders the facade, not an eager player.
+   */
+  public function testLocalVideoPageRendersLazyFacade(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_local_video',
+      'name' => 'Lazy Init Test Video',
+      'status' => TRUE,
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Facade wrapper must be present.
+    $this->assertSession()->responseContains('data-lazy-player="true"');
+
+    // No eager initialization on page load.
+    $this->assertSession()->responseNotContains('data-videojs-initialized');
+
+    // No data-setup (VideoJS auto-init must be disabled).
+    $this->assertSession()->responseNotContains('data-setup');
+
+    // Play button must be present and accessible.
+    $this->assertSession()->responseContains('videojs-lazy-facade__play-btn');
+    $this->assertSession()->responseContains('aria-label=');
+    $this->assertSession()->responseContains('tabindex="0"');
+  }
+
+  /**
+   * Tests that a YouTube entity page renders the facade, not an eager player.
+   */
+  public function testYoutubePageRendersLazyFacade(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_youtube',
+      'name' => 'Lazy Init Test YouTube',
+      'status' => TRUE,
+      'field_youtube_url' => [
+        'uri' => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      ],
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+    $this->assertSession()->statusCodeEquals(200);
+
+    $this->assertSession()->responseContains('data-lazy-player="true"');
+    $this->assertSession()->responseNotContains('data-videojs-initialized');
+    $this->assertSession()->responseNotContains('data-setup');
+  }
+
+  /**
+   * Tests that a remote video page renders the facade, not an eager player.
+   */
+  public function testRemoteVideoPageRendersLazyFacade(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_remote_video',
+      'name' => 'Lazy Init Test Remote',
+      'status' => TRUE,
+      'field_remote_url' => [
+        'uri' => 'https://example.com/video.mp4',
+      ],
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+    $this->assertSession()->statusCodeEquals(200);
+
+    $this->assertSession()->responseContains('data-lazy-player="true"');
+    $this->assertSession()->responseNotContains('data-videojs-initialized');
+    $this->assertSession()->responseNotContains('data-setup');
+  }
+
+  /**
+   * Tests that multiple video entities on a listing page all use the facade.
+   *
+   * Simulates an archive listing with multiple thumbnails and asserts that
+   * zero players are eagerly initialized.
+   */
+  public function testMultipleVideosOnListingPageAllUseFacade(): void {
+    // Create several video entities.
+    for ($i = 1; $i <= 3; $i++) {
+      $entity = VideoJsMedia::create([
+        'type' => 'videojs_local_video',
+        'name' => "Archive Video {$i}",
+        'status' => TRUE,
+      ]);
+      $entity->save();
+    }
+
+    // Visit the videojs_media collection page (default listing).
+    $this->drupalGet('/admin/content/videojs-media');
+    $this->assertSession()->statusCodeEquals(200);
+
+    // No player should be initialized on the listing page.
+    $this->assertSession()->responseNotContains('data-videojs-initialized');
+  }
+
+  /**
+   * Tests that the lazy target video element has preload="none".
+   */
+  public function testLazyTargetHasPreloadNone(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_local_video',
+      'name' => 'Preload None Test',
+      'status' => TRUE,
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->responseContains('preload="none"');
+  }
+
+}

--- a/web/modules/custom/videojs_media/tests/src/Kernel/LazyPlayerFacadeTest.php
+++ b/web/modules/custom/videojs_media/tests/src/Kernel/LazyPlayerFacadeTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\videojs_media\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests that the player component renders the lazy-init facade markup.
+ *
+ * Verifies the facade wrapper, poster image slot, accessible play button,
+ * and hidden video element are present — and that no eager VideoJS
+ * initialization attribute (data-videojs-initialized) is present on load.
+ *
+ * @group videojs_media
+ */
+class LazyPlayerFacadeTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'file',
+    'text',
+    'link',
+    'image',
+    'taxonomy',
+    'videojs_media',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('videojs_media');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installConfig(['field', 'file', 'videojs_media']);
+    $this->installSchema('file', ['file_usage']);
+  }
+
+  /**
+   * Renders the player component with the given props and returns HTML.
+   *
+   * @param array $props
+   *   Component props to pass.
+   *
+   * @return string
+   *   Rendered HTML string.
+   */
+  private function renderPlayer(array $props): string {
+    $build = [
+      '#type' => 'component',
+      '#component' => 'videojs_media:player',
+      '#props' => $props + [
+        'entity_type' => 'videojs_media',
+        'bundle' => 'videojs_local_video',
+        'field_media_file' => [],
+        'field_remote_url' => [],
+        'field_youtube_url' => [],
+        'field_poster_image' => [],
+        'field_subtitle' => [],
+        'enable_viewport_monitoring' => FALSE,
+      ],
+    ];
+    return (string) \Drupal::service('renderer')->renderRoot($build);
+  }
+
+  /**
+   * Tests that the facade wrapper div is rendered.
+   */
+  public function testFacadeWrapperIsRendered(): void {
+    $rendered = $this->renderPlayer([]);
+    $this->assertStringContainsString(
+      'class="videojs-lazy-facade"',
+      $rendered,
+      'Facade wrapper div must be present.',
+    );
+    $this->assertStringContainsString(
+      'data-lazy-player="true"',
+      $rendered,
+      'Facade wrapper must have data-lazy-player="true".',
+    );
+  }
+
+  /**
+   * Tests that the accessible play button is rendered with correct attributes.
+   */
+  public function testFacadePlayButtonAccessibility(): void {
+    $rendered = $this->renderPlayer([]);
+    $this->assertStringContainsString(
+      'class="videojs-lazy-facade__play-btn"',
+      $rendered,
+      'Facade play button must be present.',
+    );
+    $this->assertStringContainsString(
+      'role="button"',
+      $rendered,
+      'Play button must have role="button".',
+    );
+    $this->assertStringContainsString(
+      'tabindex="0"',
+      $rendered,
+      'Play button must be keyboard-focusable (tabindex="0").',
+    );
+    $this->assertStringContainsString(
+      'aria-label=',
+      $rendered,
+      'Play button must have an aria-label attribute.',
+    );
+  }
+
+  /**
+   * Tests that the hidden video element has the lazy-target class.
+   */
+  public function testVideoElementHasLazyTargetClass(): void {
+    $rendered = $this->renderPlayer([]);
+    $this->assertStringContainsString(
+      'videojs-lazy-target',
+      $rendered,
+      'Video element must have the videojs-lazy-target class.',
+    );
+    $this->assertStringContainsString(
+      'class="video-js videojs-lazy-target"',
+      $rendered,
+      'Video element must have both video-js and videojs-lazy-target classes.',
+    );
+  }
+
+  /**
+   * Tests that no data-videojs-initialized attribute is present on page load.
+   */
+  public function testNoEagerInitializationAttribute(): void {
+    $rendered = $this->renderPlayer([]);
+    $this->assertStringNotContainsString(
+      'data-videojs-initialized',
+      $rendered,
+      'data-videojs-initialized must not be present on initial render — players are lazy.',
+    );
+  }
+
+  /**
+   * Tests that no data-setup attribute is present (no VideoJS auto-init).
+   */
+  public function testNoDataSetupAttribute(): void {
+    $rendered = $this->renderPlayer([]);
+    $this->assertStringNotContainsString(
+      'data-setup',
+      $rendered,
+      'data-setup must not be present — VideoJS auto-init must be disabled.',
+    );
+  }
+
+  /**
+   * Tests that audio bundles do not render a play button facade.
+   */
+  public function testAudioBundleHasNoPlayButton(): void {
+    $rendered = $this->renderPlayer(['bundle' => 'videojs_local_audio']);
+    $this->assertStringNotContainsString(
+      'videojs-lazy-facade__play-btn',
+      $rendered,
+      'Audio players must not render a facade play button.',
+    );
+  }
+
+  /**
+   * Tests that audio bundles still render the facade wrapper.
+   */
+  public function testAudioBundleHasFacadeWrapper(): void {
+    $rendered = $this->renderPlayer(['bundle' => 'videojs_local_audio']);
+    $this->assertStringContainsString(
+      'data-lazy-player="true"',
+      $rendered,
+      'Audio facade wrapper must still have data-lazy-player="true".',
+    );
+    $this->assertStringContainsString(
+      'data-lazy-player-audio="true"',
+      $rendered,
+      'Audio facade wrapper must have data-lazy-player-audio="true".',
+    );
+  }
+
+  /**
+   * Tests that preload="none" is set on the video element.
+   */
+  public function testPreloadNoneAttribute(): void {
+    $rendered = $this->renderPlayer([]);
+    $this->assertStringContainsString(
+      'preload="none"',
+      $rendered,
+      'Video element must have preload="none" to prevent eager buffering.',
+    );
+  }
+
+}


### PR DESCRIPTION
Closes #87. Wraps video in lazy facade with poster + accessible play button. Uses IntersectionObserver for page players and Bootstrap modal events for modal players (dispose on close). Adds LazyPlayerFacadeTest (Kernel) and LazyInitializationTest (Functional).