### PR TITLE
Issue #88: Dispose player on modal close

### DIFF
--- a/tests/e2e/player-disposal.spec.js
+++ b/tests/e2e/player-disposal.spec.js
@@ -1,0 +1,182 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+/**
+ * @file
+ * E2E tests for VideoJS player disposal on modal close.
+ *
+ * Verifies that:
+ * - After closing a modal, no VideoJS player instance remains active
+ *   (data-videojs-initialized is removed / absent).
+ * - Re-opening the same modal re-initializes the player correctly.
+ * - Repeated open/close cycles produce no console errors.
+ *
+ * Prerequisites:
+ *   - DDEV running (`ddev start`)
+ *   - At least one archive_media node linked to a Skate Date taxonomy term
+ *   - The archive_by_date view accessible at /archive/{tid}
+ */
+
+/**
+ * Resolve the archive page URL dynamically.
+ *
+ * Visits the Drupal JSON:API taxonomy endpoint to find the first Skate Date
+ * term, then returns /archive/{tid}. Falls back to /archive/3 if the API
+ * is unavailable.
+ *
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @returns {Promise<string>}
+ */
+async function getArchiveUrl(request) {
+  try {
+    const resp = await request.get('/jsonapi/taxonomy_term/skate_date', {
+      params: { 'page[limit]': 1 },
+    });
+    if (resp.ok()) {
+      const json = await resp.json();
+      if (json.data && json.data.length > 0) {
+        const tid = json.data[0].attributes.drupal_internal__tid;
+        return `/archive/${tid}`;
+      }
+    }
+  }
+  catch {
+    // Fall through to default.
+  }
+  return '/archive/3';
+}
+
+// ---------------------------------------------------------------------------
+// Test suite: Player Disposal Lifecycle
+// ---------------------------------------------------------------------------
+test.describe('VideoJS Player Disposal on Modal Close', () => {
+
+  test('player is not initialized before modal opens', async ({ page, request }) => {
+    const url = await getArchiveUrl(request);
+    await page.goto(url);
+
+    // Wait for at least one masonry item to appear.
+    await page.locator('.masonry-item').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+    // No player should be initialized before any modal is opened.
+    const initializedPlayers = page.locator('[data-videojs-initialized]');
+    await expect(initializedPlayers).toHaveCount(0);
+  });
+
+  test('opening a modal initializes the player', async ({ page, request }) => {
+    const url = await getArchiveUrl(request);
+    await page.goto(url);
+
+    await page.locator('.masonry-item').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+    // Click the first masonry item to open the modal.
+    await page.locator('.masonry-item').first().click();
+
+    // Wait for the Bootstrap modal to be visible.
+    const modal = page.locator('.modal.show').first();
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    // The player inside the modal should now be initialized.
+    const playerInModal = modal.locator('[data-videojs-initialized]');
+    await expect(playerInModal).toHaveCount(1, { timeout: 5_000 });
+  });
+
+  test('closing a modal disposes the player — data-videojs-initialized is removed', async ({ page, request }) => {
+    const url = await getArchiveUrl(request);
+    await page.goto(url);
+
+    await page.locator('.masonry-item').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+    // Open modal.
+    await page.locator('.masonry-item').first().click();
+    const modal = page.locator('.modal.show').first();
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    // Wait for player to initialize.
+    await expect(modal.locator('[data-videojs-initialized]')).toHaveCount(1, { timeout: 5_000 });
+
+    // Close the modal via the close button.
+    await modal.locator('[data-bs-dismiss="modal"], .btn-close').first().click();
+
+    // Wait for modal to be hidden.
+    await expect(modal).not.toBeVisible({ timeout: 5_000 });
+
+    // After close, no initialized player should remain.
+    const initializedPlayers = page.locator('[data-videojs-initialized]');
+    await expect(initializedPlayers).toHaveCount(0);
+  });
+
+  test('re-opening the same modal re-initializes the player', async ({ page, request }) => {
+    const url = await getArchiveUrl(request);
+    await page.goto(url);
+
+    await page.locator('.masonry-item').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+    const firstItem = page.locator('.masonry-item').first();
+
+    // Open modal.
+    await firstItem.click();
+    const modal = page.locator('.modal.show').first();
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+    await expect(modal.locator('[data-videojs-initialized]')).toHaveCount(1, { timeout: 5_000 });
+
+    // Close modal.
+    await modal.locator('[data-bs-dismiss="modal"], .btn-close').first().click();
+    await expect(modal).not.toBeVisible({ timeout: 5_000 });
+
+    // Re-open the same modal.
+    await firstItem.click();
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    // Player must be re-initialized.
+    await expect(modal.locator('[data-videojs-initialized]')).toHaveCount(1, { timeout: 5_000 });
+  });
+
+  test('repeated open/close cycles produce no console errors', async ({ page, request }) => {
+    const url = await getArchiveUrl(request);
+
+    const consoleErrors = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto(url);
+    await page.locator('.masonry-item').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+    const firstItem = page.locator('.masonry-item').first();
+
+    // Open and close the modal 5 times.
+    for (let i = 0; i < 5; i++) {
+      await firstItem.click();
+      const modal = page.locator('.modal.show').first();
+      await expect(modal).toBeVisible({ timeout: 5_000 });
+      await expect(modal.locator('[data-videojs-initialized]')).toHaveCount(1, { timeout: 5_000 });
+
+      await modal.locator('[data-bs-dismiss="modal"], .btn-close').first().click();
+      await expect(modal).not.toBeVisible({ timeout: 5_000 });
+    }
+
+    // No console errors should have occurred during the cycles.
+    expect(consoleErrors).toHaveLength(0);
+  });
+
+  test('no initialized players remain after closing all modals', async ({ page, request }) => {
+    const url = await getArchiveUrl(request);
+    await page.goto(url);
+
+    await page.locator('.masonry-item').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+    // Open and close the first modal.
+    await page.locator('.masonry-item').first().click();
+    const modal = page.locator('.modal.show').first();
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+    await modal.locator('[data-bs-dismiss="modal"], .btn-close').first().click();
+    await expect(modal).not.toBeVisible({ timeout: 5_000 });
+
+    // Globally, no initialized players should remain.
+    await expect(page.locator('[data-videojs-initialized]')).toHaveCount(0);
+  });
+
+});

--- a/web/modules/custom/videojs_media/tests/src/Functional/PlayerDisposalTest.php
+++ b/web/modules/custom/videojs_media/tests/src/Functional/PlayerDisposalTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\videojs_media\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\videojs_media\Entity\VideoJsMedia;
+
+/**
+ * Tests the VideoJS player disposal lifecycle for modal players.
+ *
+ * Verifies that:
+ * - A modal player element does not have data-videojs-initialized on page load.
+ * - The facade wrapper is present inside a Bootstrap modal container.
+ * - The facade can be re-initialized (no stale initialized attribute after
+ *   disposal markup is restored).
+ *
+ * @group videojs_media
+ */
+class PlayerDisposalTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'node',
+    'taxonomy',
+    'views',
+    'videojs_media',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $viewUser = $this->drupalCreateUser([
+      'view local_video videojs media',
+      'view youtube videojs media',
+      'view remote_video videojs media',
+      'access content',
+    ]);
+    $this->drupalLogin($viewUser);
+  }
+
+  /**
+   * Tests that a modal player facade is present and not eagerly initialized.
+   *
+   * The facade wrapper must exist inside a .modal container and must NOT carry
+   * data-videojs-initialized on initial page load — initialization only happens
+   * when show.bs.modal fires.
+   */
+  public function testModalPlayerFacadeNotEagerlyInitialized(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_local_video',
+      'name' => 'Modal Disposal Test Video',
+      'status' => TRUE,
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Facade wrapper must be present.
+    $this->assertSession()->responseContains('data-lazy-player="true"');
+
+    // No eager initialization — data-videojs-initialized must be absent on
+    // initial page load regardless of whether the player is in a modal.
+    $this->assertSession()->responseNotContains('data-videojs-initialized');
+
+    // No data-setup attribute — VideoJS auto-init must be disabled.
+    $this->assertSession()->responseNotContains('data-setup');
+  }
+
+  /**
+   * Tests that the facade initialized attribute is absent on fresh page load.
+   *
+   * After disposal, disposePlayerInFacade() removes
+   * data-videojs-facade-initialized so the element can be re-initialized.
+   * On a fresh page load the attribute must also be absent, confirming the
+   * server-side template never sets it.
+   */
+  public function testFacadeInitializedAttributeAbsentOnLoad(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_local_video',
+      'name' => 'Facade Re-init Test',
+      'status' => TRUE,
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+    $this->assertSession()->statusCodeEquals(200);
+
+    // data-videojs-facade-initialized is set by JS only after init; the server
+    // must never render it so re-opening a modal always triggers a fresh init.
+    $this->assertSession()->responseNotContains('data-videojs-facade-initialized');
+  }
+
+  /**
+   * Tests that the lazy target video element carries preload="none".
+   *
+   * This prevents the browser from buffering video data before the user
+   * explicitly opens the modal, reducing idle CPU and bandwidth usage.
+   */
+  public function testModalPlayerVideoHasPreloadNone(): void {
+    $entity = VideoJsMedia::create([
+      'type' => 'videojs_local_video',
+      'name' => 'Modal Preload None Test',
+      'status' => TRUE,
+    ]);
+    $entity->save();
+
+    $this->drupalGet("/videojs-media/{$entity->id()}");
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->responseContains('preload="none"');
+  }
+
+  /**
+   * Tests that multiple video entities on a page all use the lazy facade.
+   *
+   * Ensures that even when several modal-capable players are present, none
+   * are eagerly initialized — all must wait for show.bs.modal.
+   */
+  public function testMultipleModalPlayersNoneEagerlyInitialized(): void {
+    for ($i = 1; $i <= 3; $i++) {
+      $entity = VideoJsMedia::create([
+        'type' => 'videojs_local_video',
+        'name' => "Modal Video {$i}",
+        'status' => TRUE,
+      ]);
+      $entity->save();
+    }
+
+    $this->drupalGet('/admin/content/videojs-media');
+    $this->assertSession()->statusCodeEquals(200);
+
+    // No player should be initialized on the listing page.
+    $this->assertSession()->responseNotContains('data-videojs-initialized');
+    $this->assertSession()->responseNotContains('data-videojs-facade-initialized');
+  }
+
+}


### PR DESCRIPTION
Closes #88

## Summary

The modal player dispose lifecycle was already implemented in `player.js` (from issue #87): `show.bs.modal` triggers `initPlayerFromFacade()` and `hide.bs.modal` triggers `disposePlayerInFacade()`, which calls `player.dispose()`, removes `data-videojs-facade-initialized`, and restores facade overlays for re-initialization.

This PR adds the required tests:

### Functional Test — `PlayerDisposalTest.php`
- Asserts facade is present and `data-videojs-initialized` is absent on page load
- Asserts `data-videojs-facade-initialized` is never set server-side
- Asserts `preload="none"` on video elements
- Asserts multiple modal players are never eagerly initialized

### E2E Test — `player-disposal.spec.js`
- Player not initialized before modal opens
- Opening modal initializes the player
- Closing modal removes `data-videojs-initialized`
- Re-opening modal re-initializes the player
- 5x open/close cycles produce zero console errors
- No initialized players remain after all modals closed