### PR TITLE
Switch archive masonry still images to responsive_image formatter

### DIFF
--- a/config/sync/core.entity_view_display.media.image.thumbnail.yml
+++ b/config/sync/core.entity_view_display.media.image.thumbnail.yml
@@ -5,9 +5,10 @@ dependencies:
   config:
     - core.entity_view_mode.media.thumbnail
     - field.field.media.image.field_media_image
-    - image.style.archive_thumbnail
     - media.type.image
+    - responsive_image.styles.archive_responsive
   module:
+    - responsive_image
     - svg_image
 _core:
   default_config_hash: ceRep0KVUM0u_ywhviIBBNwvu_bGObVUqYMJtRS43Vw
@@ -17,10 +18,10 @@ bundle: image
 mode: thumbnail
 content:
   field_media_image:
-    type: image
+    type: responsive_image
     label: hidden
     settings:
-      image_style: archive_thumbnail
+      responsive_image_style: archive_responsive
       image_link: ''
       image_loading:
         attribute: lazy


### PR DESCRIPTION
## Problem\n\nStill images in the archive masonry grid were served at full resolution using a plain `image` formatter with the `archive_thumbnail` image style. Browsers downloaded and decoded 4K-resolution images for small masonry thumbnails, contributing to high front-end CPU cost.\n\n## Solution\n\nSwitch `media.image.thumbnail` view display to use the `responsive_image` formatter with the `archive_responsive` responsive image style. This emits a proper `<picture>` element with `srcset` breakpoints (xs→xxl, 1×/2×) so the browser downloads only the correctly-sized derivative for the current viewport and device pixel ratio.\n\nThe `archive_responsive` style already existed and maps all `fridaynightskate` breakpoints to the correct `archive_*` image style derivatives.\n\n## Changes\n\n- `config/sync/core.entity_view_display.media.image.thumbnail.yml` — formatter changed from `image` → `responsive_image`, dependency updated.