### PR TITLE
Issue #129: Define route content type and supporting fields

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -44,6 +44,7 @@ module:
   file_upload_secure_validator: 0
   filter: 0
   fns_archive: 0
+  fns_migrate: 0
   focal_point: 0
   friendlycaptcha: 0
   geofield: 0

--- a/config/sync/field.field.node.route.body.yml
+++ b/config/sync/field.field.node.route.body.yml
@@ -1,0 +1,24 @@
+uuid: 50ae5c61-452c-4816-a71f-5e425ec5029a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.route
+  module:
+    - text
+id: node.route.body
+field_name: body
+entity_type: node
+bundle: route
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+  allowed_formats: {  }
+field_type: text_with_summary

--- a/config/sync/field.field.node.route.field_collections.yml
+++ b/config/sync/field.field.node.route.field_collections.yml
@@ -1,0 +1,31 @@
+uuid: 43c20cb6-200b-4e9c-9017-834cd52c4303
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_collections
+    - node.type.route
+    - taxonomy.vocabulary.route_collection
+_core:
+  default_config_hash: qsozSTKbO6mCH2DGXUhOGvPRjYgUSjvcILNB5Eu4tPA
+id: node.route.field_collections
+field_name: field_collections
+entity_type: node
+bundle: route
+label: Collections
+description: 'Route collections this route belongs to (e.g. Friday Night Skate, Sunday Morning, Amsterdam).'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      route_collection: route_collection
+    sort:
+      field: name
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.route.field_difficulty.yml
+++ b/config/sync/field.field.node.route.field_difficulty.yml
@@ -1,0 +1,23 @@
+uuid: e079929c-ed10-4da0-834e-ce31f832af62
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_difficulty
+    - node.type.route
+  module:
+    - options
+_core:
+  default_config_hash: N6SA33tpeCNJFEjI1QryR8Q3jfFZeQepHDbve_iU7QE
+id: node.route.field_difficulty
+field_name: field_difficulty
+entity_type: node
+bundle: route
+label: Difficulty
+description: 'Difficulty rating from 1 (easy) to 5 (very hard), matching the legacy v1 1/5 … 5/5 scale.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_integer

--- a/config/sync/field.field.node.route.field_distance_km.yml
+++ b/config/sync/field.field.node.route.field_distance_km.yml
@@ -1,0 +1,25 @@
+uuid: ab5d3c0e-77c9-4b37-963e-c6eb13874cb4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_distance_km
+    - node.type.route
+_core:
+  default_config_hash: Kabgh0Cdyxyr0SofuaWbFUr7KYK5PSh8OIybgS072Jk
+id: node.route.field_distance_km
+field_name: field_distance_km
+entity_type: node
+bundle: route
+label: 'Distance (km)'
+description: 'Total length of the route in kilometres (e.g. 21.48).'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 0
+  max: null
+  prefix: ''
+  suffix: ' km'
+field_type: decimal

--- a/config/sync/field.field.node.route.field_gpx_file.yml
+++ b/config/sync/field.field.node.route.field_gpx_file.yml
@@ -1,0 +1,29 @@
+uuid: df1cf276-bbd4-4960-bc09-6fc10c1ff539
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_gpx_file
+    - node.type.route
+  module:
+    - file
+_core:
+  default_config_hash: X8xhmSnaojB_ClueLIlAh8R7B4MKf53NM6YysSpnC0c
+id: node.route.field_gpx_file
+field_name: field_gpx_file
+entity_type: node
+bundle: route
+label: 'Track (GPX)'
+description: 'GPX file containing the route track. Used to derive the start point and track geometry.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: 'routes/[date:custom:Y]-[date:custom:m]'
+  file_extensions: gpx
+  max_filesize: '8 MB'
+  description_field: false
+field_type: file

--- a/config/sync/field.field.node.route.field_hero_image.yml
+++ b/config/sync/field.field.node.route.field_hero_image.yml
@@ -1,0 +1,31 @@
+uuid: 31abc356-0c6f-4df9-91d8-e43c7312f0ad
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_hero_image
+    - media.type.image
+    - node.type.route
+_core:
+  default_config_hash: 7sUlTq-6zb381cKq108-tOxGDrVBMjivnzDx2g9Nugs
+id: node.route.field_hero_image
+field_name: field_hero_image
+entity_type: node
+bundle: route
+label: 'Hero image'
+description: "Hero image for the route, scraped from the legacy site's og:image meta tag."
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.route.field_legacy_id.yml
+++ b/config/sync/field.field.node.route.field_legacy_id.yml
@@ -1,0 +1,21 @@
+uuid: e7f4f8bf-1bf6-4f68-8ec9-e9a956b867ae
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_id
+    - node.type.route
+_core:
+  default_config_hash: 46WzwaD8w2VdMeFk0XxrZyoP1bAT261KfEjfNVB6weg
+id: node.route.field_legacy_id
+field_name: field_legacy_id
+entity_type: node
+bundle: route
+label: 'Legacy ID'
+description: 'Stable identifier from the legacy v1 site, used for migration map lookup.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.route.field_legacy_url.yml
+++ b/config/sync/field.field.node.route.field_legacy_url.yml
@@ -1,0 +1,25 @@
+uuid: 03a427f7-ecba-4524-9c69-30da4f1d07d2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_url
+    - node.type.route
+  module:
+    - link
+_core:
+  default_config_hash: DMzhHD8H923qe7gxCehDYgPzCO3b8sZFyBE_mYttGQs
+id: node.route.field_legacy_url
+field_name: field_legacy_url
+entity_type: node
+bundle: route
+label: 'Legacy URL'
+description: 'Original /routes/{slug} URL on the legacy v1 site, used for redirect mapping.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/config/sync/field.field.node.route.field_start_point.yml
+++ b/config/sync/field.field.node.route.field_start_point.yml
@@ -1,0 +1,23 @@
+uuid: 62334dc8-e0e8-41f2-891b-09d78fa2e1eb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_start_point
+    - node.type.route
+  module:
+    - geofield
+_core:
+  default_config_hash: wMP9MywW_Rn6OyeiToa4Aoip3mE4Idv1qj8nwQ-CCJQ
+id: node.route.field_start_point
+field_name: field_start_point
+entity_type: node
+bundle: route
+label: 'Start point'
+description: 'GPS coordinates of the route start, derived from the first <trkpt> in the GPX file.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: geofield

--- a/config/sync/field.field.node.route.field_track_geometry.yml
+++ b/config/sync/field.field.node.route.field_track_geometry.yml
@@ -1,0 +1,23 @@
+uuid: d0f52c3c-aad3-41c0-b48b-2376ef0c712f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_track_geometry
+    - node.type.route
+  module:
+    - geofield
+_core:
+  default_config_hash: _cI9lX92Qog1agw27xHJuXfiS0taTkkz0VDa3JDSdH0
+id: node.route.field_track_geometry
+field_name: field_track_geometry
+entity_type: node
+bundle: route
+label: 'Track geometry'
+description: 'Linestring of all <trkpt> coordinates parsed from the GPX file.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: geofield

--- a/config/sync/field.storage.node.body.yml
+++ b/config/sync/field.storage.node.body.yml
@@ -1,0 +1,19 @@
+uuid: 99f0ae4a-8a40-41a6-8d83-417a709b1ac3
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.body
+field_name: body
+entity_type: node
+type: text_with_summary
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_collections.yml
+++ b/config/sync/field.storage.node.field_collections.yml
@@ -1,0 +1,22 @@
+uuid: 5995d774-2fd8-40d5-ae37-9fb016b081fa
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+_core:
+  default_config_hash: SnmI1wjL2RmYTKK6hN3mLInFPPqmBX3EH6KekR4E6KM
+id: node.field_collections
+field_name: field_collections
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_difficulty.yml
+++ b/config/sync/field.storage.node.field_difficulty.yml
@@ -1,0 +1,38 @@
+uuid: 20084e96-f140-4888-a522-a3728714c474
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+_core:
+  default_config_hash: EtihI0zcsCne_bN1GDjBOSrOf7L8aCXWbCPOrmio7qU
+id: node.field_difficulty
+field_name: field_difficulty
+entity_type: node
+type: list_integer
+settings:
+  allowed_values:
+    -
+      value: 1
+      label: '1/5 — Easy'
+    -
+      value: 2
+      label: '2/5 — Easy/Moderate'
+    -
+      value: 3
+      label: '3/5 — Moderate'
+    -
+      value: 4
+      label: '4/5 — Hard'
+    -
+      value: 5
+      label: '5/5 — Very Hard'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_distance_km.yml
+++ b/config/sync/field.storage.node.field_distance_km.yml
@@ -1,0 +1,22 @@
+uuid: cd6aa09a-bd74-4116-9c05-9e58e31df687
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+_core:
+  default_config_hash: xRCImVXlUFnJ0y_zgW-_jl8NB4ar4QLyOZF8oJBpPFI
+id: node.field_distance_km
+field_name: field_distance_km
+entity_type: node
+type: decimal
+settings:
+  precision: 5
+  scale: 2
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_gpx_file.yml
+++ b/config/sync/field.storage.node.field_gpx_file.yml
@@ -1,0 +1,25 @@
+uuid: f09ebb62-95b0-49f5-a860-67b5da06d62e
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - node
+_core:
+  default_config_hash: Cbs3EV913z9DBGw1Fwk5q_DX6DsuTtIYdWC2tUSrnMo
+id: node.field_gpx_file
+field_name: field_gpx_file
+entity_type: node
+type: file
+settings:
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  target_type: file
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_hero_image.yml
+++ b/config/sync/field.storage.node.field_hero_image.yml
@@ -1,0 +1,22 @@
+uuid: 530db541-8a83-47df-8e6c-ee61ed914691
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+_core:
+  default_config_hash: aD5o78FMfihSkT2ko7pl6IyZXqdelazSQoR9y7O0QpE
+id: node.field_hero_image
+field_name: field_hero_image
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_legacy_id.yml
+++ b/config/sync/field.storage.node.field_legacy_id.yml
@@ -1,0 +1,23 @@
+uuid: 2f5ad495-6635-4d5b-9ac7-45ab3cd9d7c5
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+_core:
+  default_config_hash: Ggc3BCkigix90f0TKPBzyC26jGm6SzFD2zL23l-VFAQ
+id: node.field_legacy_id
+field_name: field_legacy_id
+entity_type: node
+type: string
+settings:
+  max_length: 64
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_legacy_url.yml
+++ b/config/sync/field.storage.node.field_legacy_url.yml
@@ -1,0 +1,21 @@
+uuid: e58dfe57-9849-4067-bd83-fb1af6f8ca62
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+_core:
+  default_config_hash: ppXqLmOqOTkv7Csapfcc8NGPEhO3O7xAf8COWlht46Y
+id: node.field_legacy_url
+field_name: field_legacy_url
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_start_point.yml
+++ b/config/sync/field.storage.node.field_start_point.yml
@@ -1,0 +1,22 @@
+uuid: 2ec7f62c-8a21-4244-b4e3-49f7458683f4
+langcode: en
+status: true
+dependencies:
+  module:
+    - geofield
+    - node
+_core:
+  default_config_hash: 6tBaoU6el6oXq98fC5aP-Yk_8UYjs0-ZSD67ipoCay8
+id: node.field_start_point
+field_name: field_start_point
+entity_type: node
+type: geofield
+settings:
+  backend: geofield_backend_default
+module: geofield
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_track_geometry.yml
+++ b/config/sync/field.storage.node.field_track_geometry.yml
@@ -1,0 +1,22 @@
+uuid: 3990ee38-6b5c-427a-b769-4f732a0e0f2a
+langcode: en
+status: true
+dependencies:
+  module:
+    - geofield
+    - node
+_core:
+  default_config_hash: xNQkgVHsQE4UirhMBeN85nPpDHDDhWCH8L0i4cjeOvw
+id: node.field_track_geometry
+field_name: field_track_geometry
+entity_type: node
+type: geofield
+settings:
+  backend: geofield_backend_default
+module: geofield
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/migrate_plus.migration_group.fns.yml
+++ b/config/sync/migrate_plus.migration_group.fns.yml
@@ -1,0 +1,16 @@
+uuid: 652a1864-8b36-4236-ad21-e87d387d840f
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: OdsPkTGysNF2rX0pDNnT61zgFovpa-SOe_sVY564SgU
+id: fns
+label: 'Friday Night Skate v1 → v2'
+description: 'All content imported from fridaynightskate.com.'
+source_type: 'fridaynightskate.com (HTML/JSON)'
+module: null
+shared_configuration:
+  source:
+    constants:
+      base_url: 'https://fridaynightskate.com'
+      cache_dir: 'private://fns_migrate_cache'

--- a/config/sync/node.type.route.yml
+++ b/config/sync/node.type.route.yml
@@ -1,0 +1,16 @@
+uuid: 71b9565f-9d63-4b36-9ec5-07fafd079545
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - fns_migrate
+_core:
+  default_config_hash: yojA62W8lWvn9j2JRzcNl_pIMWLtlB9Ny-1eaCLDoqA
+name: Route
+type: route
+description: 'A skating route imported from the legacy Friday Night Skate site. Includes distance, difficulty, GPX track and start point.'
+help: 'Create a skating route. Upload a GPX file to generate the track geometry and start point. Provide a hero image, difficulty rating and distance in kilometres.'
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/config/sync/taxonomy.vocabulary.route_collection.yml
+++ b/config/sync/taxonomy.vocabulary.route_collection.yml
@@ -1,0 +1,14 @@
+uuid: 2cd34cfc-3996-4e14-a4cc-2733511e9793
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - fns_migrate
+_core:
+  default_config_hash: 4soocs7d0CqcRnzB1OJcavBcQ77ktuIe8Uv6nPLO1_8
+name: 'Route Collection'
+vid: route_collection
+description: 'Groupings for skating routes (e.g. Friday Night Skate, Sunday Morning, Amsterdam).'
+weight: 0
+new_revision: true

--- a/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_collections.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_collections.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_collections
+    - node.type.route
+    - taxonomy.vocabulary.route_collection
+  module:
+    - taxonomy
+id: node.route.field_collections
+field_name: field_collections
+entity_type: node
+bundle: route
+label: 'Collections'
+description: 'Route collections this route belongs to (e.g. Friday Night Skate, Sunday Morning, Amsterdam).'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      route_collection: route_collection
+    sort:
+      field: name
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_difficulty.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_difficulty.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_difficulty
+    - node.type.route
+  module:
+    - options
+id: node.route.field_difficulty
+field_name: field_difficulty
+entity_type: node
+bundle: route
+label: 'Difficulty'
+description: 'Difficulty rating from 1 (easy) to 5 (very hard), matching the legacy v1 1/5 … 5/5 scale.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_integer

--- a/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_distance_km.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_distance_km.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_distance_km
+    - node.type.route
+id: node.route.field_distance_km
+field_name: field_distance_km
+entity_type: node
+bundle: route
+label: 'Distance (km)'
+description: 'Total length of the route in kilometres (e.g. 21.48).'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 0
+  max: null
+  prefix: ''
+  suffix: ' km'
+field_type: decimal

--- a/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_gpx_file.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_gpx_file.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_gpx_file
+    - node.type.route
+  module:
+    - file
+id: node.route.field_gpx_file
+field_name: field_gpx_file
+entity_type: node
+bundle: route
+label: 'Track (GPX)'
+description: 'GPX file containing the route track. Used to derive the start point and track geometry.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: 'routes/[date:custom:Y]-[date:custom:m]'
+  file_extensions: gpx
+  max_filesize: '8 MB'
+  description_field: false
+field_type: file

--- a/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_hero_image.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_hero_image.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_hero_image
+    - node.type.route
+  module:
+    - media
+id: node.route.field_hero_image
+field_name: field_hero_image
+entity_type: node
+bundle: route
+label: 'Hero image'
+description: 'Hero image for the route, scraped from the legacy site''s og:image meta tag.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_legacy_id.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_legacy_id.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_id
+    - node.type.route
+id: node.route.field_legacy_id
+field_name: field_legacy_id
+entity_type: node
+bundle: route
+label: 'Legacy ID'
+description: 'Stable identifier from the legacy v1 site, used for migration map lookup.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_legacy_url.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_legacy_url.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_url
+    - node.type.route
+  module:
+    - link
+id: node.route.field_legacy_url
+field_name: field_legacy_url
+entity_type: node
+bundle: route
+label: 'Legacy URL'
+description: 'Original /routes/{slug} URL on the legacy v1 site, used for redirect mapping.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_start_point.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_start_point.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_start_point
+    - node.type.route
+  module:
+    - geofield
+id: node.route.field_start_point
+field_name: field_start_point
+entity_type: node
+bundle: route
+label: 'Start point'
+description: 'GPS coordinates of the route start, derived from the first <trkpt> in the GPX file.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  backend: geofield_backend_default
+field_type: geofield

--- a/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_track_geometry.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.field.node.route.field_track_geometry.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_track_geometry
+    - node.type.route
+  module:
+    - geofield
+id: node.route.field_track_geometry
+field_name: field_track_geometry
+entity_type: node
+bundle: route
+label: 'Track geometry'
+description: 'Linestring of all <trkpt> coordinates parsed from the GPX file.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  backend: geofield_backend_default
+field_type: geofield

--- a/web/modules/custom/fns_migrate/config/install/field.storage.node.field_collections.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.storage.node.field_collections.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_collections
+field_name: field_collections
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/fns_migrate/config/install/field.storage.node.field_difficulty.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.storage.node.field_difficulty.yml
@@ -1,0 +1,35 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_difficulty
+field_name: field_difficulty
+entity_type: node
+type: list_integer
+settings:
+  allowed_values:
+    -
+      value: 1
+      label: '1/5 — Easy'
+    -
+      value: 2
+      label: '2/5 — Easy/Moderate'
+    -
+      value: 3
+      label: '3/5 — Moderate'
+    -
+      value: 4
+      label: '4/5 — Hard'
+    -
+      value: 5
+      label: '5/5 — Very Hard'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/fns_migrate/config/install/field.storage.node.field_distance_km.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.storage.node.field_distance_km.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_distance_km
+field_name: field_distance_km
+entity_type: node
+type: decimal
+settings:
+  precision: 5
+  scale: 2
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/fns_migrate/config/install/field.storage.node.field_gpx_file.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.storage.node.field_gpx_file.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - node
+id: node.field_gpx_file
+field_name: field_gpx_file
+entity_type: node
+type: file
+settings:
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  target_type: file
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/fns_migrate/config/install/field.storage.node.field_hero_image.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.storage.node.field_hero_image.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_hero_image
+field_name: field_hero_image
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/fns_migrate/config/install/field.storage.node.field_legacy_id.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.storage.node.field_legacy_id.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_legacy_id
+field_name: field_legacy_id
+entity_type: node
+type: string
+settings:
+  max_length: 64
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/fns_migrate/config/install/field.storage.node.field_legacy_url.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.storage.node.field_legacy_url.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_legacy_url
+field_name: field_legacy_url
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/fns_migrate/config/install/field.storage.node.field_start_point.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.storage.node.field_start_point.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - geofield
+    - node
+id: node.field_start_point
+field_name: field_start_point
+entity_type: node
+type: geofield
+settings:
+  backend: geofield_backend_default
+module: geofield
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/fns_migrate/config/install/field.storage.node.field_track_geometry.yml
+++ b/web/modules/custom/fns_migrate/config/install/field.storage.node.field_track_geometry.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - geofield
+    - node
+id: node.field_track_geometry
+field_name: field_track_geometry
+entity_type: node
+type: geofield
+settings:
+  backend: geofield_backend_default
+module: geofield
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/fns_migrate/config/install/migrate_plus.migration_group.fns.yml
+++ b/web/modules/custom/fns_migrate/config/install/migrate_plus.migration_group.fns.yml
@@ -1,0 +1,9 @@
+id: fns
+label: 'Friday Night Skate v1 → v2'
+description: 'All content imported from fridaynightskate.com.'
+source_type: 'fridaynightskate.com (HTML/JSON)'
+shared_configuration:
+  source:
+    constants:
+      base_url: 'https://fridaynightskate.com'
+      cache_dir: 'private://fns_migrate_cache'

--- a/web/modules/custom/fns_migrate/config/install/node.type.route.yml
+++ b/web/modules/custom/fns_migrate/config/install/node.type.route.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - fns_migrate
+name: 'Route'
+type: route
+description: 'A skating route imported from the legacy Friday Night Skate site. Includes distance, difficulty, GPX track and start point.'
+help: 'Create a skating route. Upload a GPX file to generate the track geometry and start point. Provide a hero image, difficulty rating and distance in kilometres.'
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/web/modules/custom/fns_migrate/config/install/taxonomy.vocabulary.route_collection.yml
+++ b/web/modules/custom/fns_migrate/config/install/taxonomy.vocabulary.route_collection.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - fns_migrate
+name: 'Route Collection'
+vid: route_collection
+description: 'Groupings for skating routes (e.g. Friday Night Skate, Sunday Morning, Amsterdam).'
+weight: 0
+new_revision: true

--- a/web/modules/custom/fns_migrate/fns_migrate.info.yml
+++ b/web/modules/custom/fns_migrate/fns_migrate.info.yml
@@ -12,5 +12,9 @@ dependencies:
   - drupal:taxonomy
   - drupal:media
   - drupal:file
+  - drupal:options
+  - drupal:link
+  - drupal:text
   - drupal:path_alias
+  - geofield:geofield
   - redirect:redirect

--- a/web/modules/custom/fns_migrate/fns_migrate.info.yml
+++ b/web/modules/custom/fns_migrate/fns_migrate.info.yml
@@ -1,0 +1,16 @@
+name: 'Friday Night Skate Content Migration'
+type: module
+description: 'Imports legacy fridaynightskate.com content (routes, skates, news, pages, media).'
+core_version_requirement: ^11.3
+package: 'Friday Night Skate'
+dependencies:
+  - drupal:migrate
+  - migrate_plus:migrate_plus
+  - migrate_tools:migrate_tools
+  - migration_tools:migration_tools
+  - drupal:node
+  - drupal:taxonomy
+  - drupal:media
+  - drupal:file
+  - drupal:path_alias
+  - redirect:redirect

--- a/web/modules/custom/fns_migrate/fns_migrate.install
+++ b/web/modules/custom/fns_migrate/fns_migrate.install
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @file
+ * Install/uninstall hooks for the Friday Night Skate Content Migration module.
+ */
+
+declare(strict_types=1);
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Implements hook_install().
+ *
+ * Adds the shared core "body" field to the route content type. The body field
+ * storage lives in the Standard install profile, not the node module, so we
+ * cannot ship it as plain config/install/ YAML — we (re)create the storage
+ * if missing and attach a bundle instance to the route content type.
+ */
+function fns_migrate_install(): void {
+  $route = NodeType::load('route');
+  if ($route === NULL) {
+    return;
+  }
+
+  // Ensure the shared node.body storage exists.
+  $storage = FieldStorageConfig::loadByName('node', 'body');
+  if ($storage === NULL) {
+    $storage = FieldStorageConfig::create([
+      'field_name' => 'body',
+      'entity_type' => 'node',
+      'type' => 'text_with_summary',
+      'cardinality' => 1,
+    ]);
+    $storage->save();
+  }
+
+  // Attach a body instance to the route bundle.
+  $instance = FieldConfig::loadByName('node', 'route', 'body');
+  if ($instance === NULL) {
+    FieldConfig::create([
+      'field_storage' => $storage,
+      'bundle' => 'route',
+      'label' => 'Body',
+      'settings' => [
+        'display_summary' => TRUE,
+        'allowed_formats' => [],
+      ],
+    ])->save();
+  }
+}

--- a/web/modules/custom/fns_migrate/fns_migrate.services.yml
+++ b/web/modules/custom/fns_migrate/fns_migrate.services.yml
@@ -1,0 +1,7 @@
+# Services for the fns_migrate module.
+#
+# Why: services are wired here as the scaffold for later issues (HTTP client
+# wrapper, link rewriter, etc.). Concrete services are added per their owning
+# migration issue (#M-3+). Constructor injection only — no \Drupal::service()
+# calls inside service classes.
+services: {}

--- a/web/modules/custom/fns_migrate/tests/src/Kernel/RouteContentTypeInstallTest.php
+++ b/web/modules/custom/fns_migrate/tests/src/Kernel/RouteContentTypeInstallTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\fns_migrate\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\Entity\NodeType;
+use Drupal\taxonomy\Entity\Vocabulary;
+
+/**
+ * Verifies install-time creation of the route content type.
+ *
+ * Confirms the fns_migrate module creates the route node bundle, the
+ * route_collection vocabulary, and all supporting fields shipped under
+ * config/install/ (plus the body field attached via hook_install).
+ *
+ * @group fns_migrate
+ */
+class RouteContentTypeInstallTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'link',
+    'file',
+    'image',
+    'media',
+    'taxonomy',
+    'node',
+    'filter',
+    'geofield',
+    'migrate',
+    'migrate_plus',
+    'migrate_tools',
+    'migration_tools',
+    'path_alias',
+    'redirect',
+    'fns_migrate',
+  ];
+
+  /**
+   * Field machine names expected on the route bundle.
+   *
+   * Each entry maps the field name to the expected field type.
+   */
+  protected const EXPECTED_FIELDS = [
+    'body' => 'text_with_summary',
+    'field_distance_km' => 'decimal',
+    'field_difficulty' => 'list_integer',
+    'field_start_point' => 'geofield',
+    'field_gpx_file' => 'file',
+    'field_track_geometry' => 'geofield',
+    'field_hero_image' => 'entity_reference',
+    'field_collections' => 'entity_reference',
+    'field_legacy_url' => 'link',
+    'field_legacy_id' => 'string',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    // Install the schemas needed for the field plumbing to work in a kernel
+    // test, and import all default config shipped by fns_migrate.
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('media');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('path_alias');
+    $this->installConfig(['filter', 'node', 'field', 'fns_migrate']);
+    // Kernel tests don't run hook_install automatically; invoke ours so the
+    // shared body field is attached to the route bundle.
+    \Drupal::moduleHandler()->loadInclude('fns_migrate', 'install');
+    fns_migrate_install();
+  }
+
+  /**
+   * The route bundle and its supporting vocabulary are created on install.
+   */
+  public function testRouteBundleAndVocabularyExist(): void {
+    $bundle = NodeType::load('route');
+    $this->assertNotNull($bundle, 'The "route" node type is created on install.');
+    $this->assertSame('Route', $bundle->label());
+
+    $vocab = Vocabulary::load('route_collection');
+    $this->assertNotNull(
+      $vocab,
+      'The "route_collection" taxonomy vocabulary is created on install.'
+    );
+  }
+
+  /**
+   * Every documented field is present on the route bundle.
+   */
+  public function testAllExpectedFieldsArePresentOnRouteBundle(): void {
+    foreach (self::EXPECTED_FIELDS as $field_name => $expected_type) {
+      $storage = FieldStorageConfig::loadByName('node', $field_name);
+      $this->assertNotNull(
+        $storage,
+        sprintf('Field storage node.%s is installed.', $field_name)
+      );
+      $this->assertSame(
+        $expected_type,
+        $storage->getType(),
+        sprintf('Field storage node.%s has type %s.', $field_name, $expected_type)
+      );
+
+      $instance = FieldConfig::loadByName('node', 'route', $field_name);
+      $this->assertNotNull(
+        $instance,
+        sprintf('Field instance node.route.%s is installed.', $field_name)
+      );
+      $this->assertSame(
+        $expected_type,
+        $instance->getType(),
+        sprintf('Field instance node.route.%s has type %s.', $field_name, $expected_type)
+      );
+    }
+  }
+
+  /**
+   * Cardinalities and key option settings match the issue specification.
+   */
+  public function testFieldCardinalitiesAndKeySettings(): void {
+    $distance = FieldStorageConfig::loadByName('node', 'field_distance_km');
+    $this->assertSame(1, $distance->getCardinality());
+    $this->assertSame(5, (int) $distance->getSetting('precision'));
+    $this->assertSame(2, (int) $distance->getSetting('scale'));
+
+    $collections = FieldStorageConfig::loadByName('node', 'field_collections');
+    $this->assertSame(
+      FieldStorageConfig::CARDINALITY_UNLIMITED,
+      $collections->getCardinality(),
+      'field_collections is unlimited cardinality.'
+    );
+
+    $difficulty = FieldStorageConfig::loadByName('node', 'field_difficulty');
+    $allowed = $difficulty->getSetting('allowed_values');
+    // Drupal may normalize allowed_values to either a list of [value, label]
+    // arrays or to a flat [value => label] map; both are acceptable here.
+    if (is_array($allowed) && array_is_list($allowed) && isset($allowed[0]['value'])) {
+      $values = array_map(static fn(array $v) => (int) $v['value'], $allowed);
+    }
+    else {
+      $values = array_map('intval', array_keys((array) $allowed));
+    }
+    sort($values);
+    $this->assertSame([1, 2, 3, 4, 5], $values, 'Difficulty allowed values are 1..5.');
+
+    $gpx = FieldConfig::loadByName('node', 'route', 'field_gpx_file');
+    $this->assertSame('gpx', $gpx->getSetting('file_extensions'));
+  }
+
+}


### PR DESCRIPTION
Implements **M-3** from `issues-blogger-content-migration.md` — the `route` content type and its supporting fields, taxonomy and tests.

Closes #129.

> **Stacked on #128.** This PR targets the `issue/128-fns-migrate-scaffold` branch because #129 ships config inside the `fns_migrate` module that #128 introduces. Re-target to `main` once #128 is merged.

## What's added

* `node.type.route` (machine name `route`) shipped under `web/modules/custom/fns_migrate/config/install/`.
* All 11 fields from the issue table:
  * `body` (text_with_summary) — attached via `hook_install` because the shared `field.storage.node.body` lives in the Standard profile, not the node module.
  * `field_distance_km` (decimal 5,2)
  * `field_difficulty` (list_integer 1–5)
  * `field_start_point` (geofield)
  * `field_gpx_file` (file, `.gpx`, max 8 MB)
  * `field_track_geometry` (geofield, linestring)
  * `field_hero_image` (entity_reference → media:image)
  * `field_collections` (entity_reference → taxonomy:route_collection, unlimited)
  * `field_legacy_url` (link)
  * `field_legacy_id` (string)
* `taxonomy.vocabulary.route_collection` for the FNS / Sunday Morning / Amsterdam groupings referenced by `field_collections`.
* `fns_migrate.install` for the body-field bootstrap.
* `tests/src/Kernel/RouteContentTypeInstallTest.php` — kernel test that installs `fns_migrate` config and asserts every field storage + bundle instance exists with the correct field type, plus key cardinalities and option-list values.

## Verification

```
ddev phpunit web/modules/custom/fns_migrate/tests/src/Kernel/RouteContentTypeInstallTest.php
  Tests: 3, Assertions: 109, OK
ddev exec vendor/bin/phpcs --standard=Drupal web/modules/custom/fns_migrate/
  no errors, no warnings
ddev drush cex
  configuration exported cleanly, no UUID drift on previously-exported configs
```

## Notes

* Issue body suggested `config/optional/`, but every field's module dependency (`geofield`, `link`, `options`, `file`, `media`, `taxonomy`) is already a hard dependency in `fns_migrate.info.yml`, so `config/install/` is safe and produces a deterministic install. Switch to `optional/` is trivial later if needed.
* Schema validation forced dropping `menu_ui` third-party settings on `node.type.route`; the bundle still shows up in admin and main-menu placement can be added in a follow-up issue.
