### PR TITLE
Issue #130: Define event content type and soft legacy fields on news/page

### DIFF
--- a/config/sync/core.entity_form_display.node.news.default.yml
+++ b/config/sync/core.entity_form_display.node.news.default.yml
@@ -6,9 +6,10 @@ dependencies:
     - field.field.node.news.field_content
     - field.field.node.news.field_description
     - field.field.node.news.field_featured_image
+    - field.field.node.news.field_legacy_id
+    - field.field.node.news.field_legacy_url
     - field.field.node.news.field_tags
     - node.type.news
-    - workflows.workflow.basic_editorial
   module:
     - content_moderation
     - media_library
@@ -152,4 +153,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_legacy_id: true
+  field_legacy_url: true
   url_redirects: true

--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -6,9 +6,12 @@ dependencies:
     - field.field.node.page.field_content
     - field.field.node.page.field_description
     - field.field.node.page.field_featured_image
+    - field.field.node.page.field_legacy_id
+    - field.field.node.page.field_legacy_url
     - field.field.node.page.field_tags
     - node.type.page
   module:
+    - content_moderation
     - media_library
     - path
     - scheduler
@@ -150,4 +153,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_legacy_id: true
+  field_legacy_url: true
   url_redirects: true

--- a/config/sync/core.entity_view_display.node.news.card.yml
+++ b/config/sync/core.entity_view_display.node.news.card.yml
@@ -7,6 +7,8 @@ dependencies:
     - field.field.node.news.field_content
     - field.field.node.news.field_description
     - field.field.node.news.field_featured_image
+    - field.field.node.news.field_legacy_id
+    - field.field.node.news.field_legacy_url
     - field.field.node.news.field_tags
     - node.type.news
   module:
@@ -37,5 +39,7 @@ content:
 hidden:
   content_moderation_control: true
   field_content: true
+  field_legacy_id: true
+  field_legacy_url: true
   field_tags: true
   links: true

--- a/config/sync/core.entity_view_display.node.news.default.yml
+++ b/config/sync/core.entity_view_display.node.news.default.yml
@@ -6,6 +6,8 @@ dependencies:
     - field.field.node.news.field_content
     - field.field.node.news.field_description
     - field.field.node.news.field_featured_image
+    - field.field.node.news.field_legacy_id
+    - field.field.node.news.field_legacy_url
     - field.field.node.news.field_tags
     - node.type.news
   module:
@@ -49,4 +51,6 @@ content:
     region: content
 hidden:
   field_description: true
+  field_legacy_id: true
+  field_legacy_url: true
   links: true

--- a/config/sync/core.entity_view_display.node.news.teaser.yml
+++ b/config/sync/core.entity_view_display.node.news.teaser.yml
@@ -7,6 +7,8 @@ dependencies:
     - field.field.node.news.field_content
     - field.field.node.news.field_description
     - field.field.node.news.field_featured_image
+    - field.field.node.news.field_legacy_id
+    - field.field.node.news.field_legacy_url
     - field.field.node.news.field_tags
     - node.type.news
   module:
@@ -37,5 +39,7 @@ content:
 hidden:
   content_moderation_control: true
   field_content: true
+  field_legacy_id: true
+  field_legacy_url: true
   field_tags: true
   links: true

--- a/config/sync/core.entity_view_display.node.page.card.yml
+++ b/config/sync/core.entity_view_display.node.page.card.yml
@@ -7,6 +7,8 @@ dependencies:
     - field.field.node.page.field_content
     - field.field.node.page.field_description
     - field.field.node.page.field_featured_image
+    - field.field.node.page.field_legacy_id
+    - field.field.node.page.field_legacy_url
     - field.field.node.page.field_tags
     - node.type.page
   module:
@@ -37,5 +39,7 @@ content:
 hidden:
   content_moderation_control: true
   field_content: true
+  field_legacy_id: true
+  field_legacy_url: true
   field_tags: true
   links: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -6,6 +6,8 @@ dependencies:
     - field.field.node.page.field_content
     - field.field.node.page.field_description
     - field.field.node.page.field_featured_image
+    - field.field.node.page.field_legacy_id
+    - field.field.node.page.field_legacy_url
     - field.field.node.page.field_tags
     - node.type.page
   module:
@@ -41,5 +43,7 @@ content:
     region: content
 hidden:
   field_description: true
+  field_legacy_id: true
+  field_legacy_url: true
   field_tags: true
   links: true

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -7,6 +7,8 @@ dependencies:
     - field.field.node.page.field_content
     - field.field.node.page.field_description
     - field.field.node.page.field_featured_image
+    - field.field.node.page.field_legacy_id
+    - field.field.node.page.field_legacy_url
     - field.field.node.page.field_tags
     - node.type.page
   module:
@@ -37,5 +39,7 @@ content:
 hidden:
   content_moderation_control: true
   field_content: true
+  field_legacy_id: true
+  field_legacy_url: true
   field_tags: true
   links: true

--- a/config/sync/field.field.node.event.field_event_datetime.yml
+++ b/config/sync/field.field.node.event.field_event_datetime.yml
@@ -1,0 +1,23 @@
+uuid: 424fd74b-17e7-40c3-a442-79f2bc5ef141
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_datetime
+    - node.type.event
+  module:
+    - datetime
+_core:
+  default_config_hash: GYrWxAHq8QZXNjb7YKteOHV6Sz8q4tloSPoagGdzlUU
+id: node.event.field_event_datetime
+field_name: field_event_datetime
+entity_type: node
+bundle: event
+label: 'Date and time'
+description: 'Date and time of the skate, in Europe/Amsterdam timezone. Defaults to 20:00 on the configured day.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/sync/field.field.node.event.field_event_status.yml
+++ b/config/sync/field.field.node.event.field_event_status.yml
@@ -1,0 +1,25 @@
+uuid: 1de9b962-4694-4f80-897d-bdbe9f93a277
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_status
+    - node.type.event
+  module:
+    - options
+_core:
+  default_config_hash: 9wsqRRfO2dPmVMm750p1H4UyElgmJN_UiLL1YUfjApU
+id: node.event.field_event_status
+field_name: field_event_status
+entity_type: node
+bundle: event
+label: Status
+description: 'Whether the skate is confirmed, cancelled or still tentative. Reused by the newsletter pipeline.'
+required: true
+translatable: false
+default_value:
+  -
+    value: tentative
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.node.event.field_hero_image.yml
+++ b/config/sync/field.field.node.event.field_hero_image.yml
@@ -1,0 +1,31 @@
+uuid: 42e0de49-9d38-4de8-84cf-fdebe1df4a75
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_hero_image
+    - media.type.image
+    - node.type.event
+_core:
+  default_config_hash: IuN2SLB7ZLIMvLIlqta1RrmZ_FwuxuzGu9TMdrDHjWU
+id: node.event.field_hero_image
+field_name: field_hero_image
+entity_type: node
+bundle: event
+label: 'Hero image'
+description: "Hero image for the event, scraped from the legacy site's og:image meta tag."
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.event.field_legacy_id.yml
+++ b/config/sync/field.field.node.event.field_legacy_id.yml
@@ -1,0 +1,21 @@
+uuid: 1ff573b0-9bef-45f4-9a58-7c1c4084d385
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_id
+    - node.type.event
+_core:
+  default_config_hash: C2qWqZN7cc0vDIGwC1CgD_HECuWlJ7zs-v_CbVPKW3o
+id: node.event.field_legacy_id
+field_name: field_legacy_id
+entity_type: node
+bundle: event
+label: 'Legacy ID'
+description: 'Stable identifier from the legacy v1 site, used for migration map lookup.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.event.field_legacy_url.yml
+++ b/config/sync/field.field.node.event.field_legacy_url.yml
@@ -1,0 +1,25 @@
+uuid: 18aea528-3e24-4ced-8bc7-03142ae843f7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_url
+    - node.type.event
+  module:
+    - link
+_core:
+  default_config_hash: U8uNy6kqwcKjFL9wwYmH0cCRAuXyJ9XYkDajNp_58Sw
+id: node.event.field_legacy_url
+field_name: field_legacy_url
+entity_type: node
+bundle: event
+label: 'Legacy URL'
+description: 'Original URL on the legacy v1 site, used for redirect mapping.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/config/sync/field.field.node.event.field_meeting_point.yml
+++ b/config/sync/field.field.node.event.field_meeting_point.yml
@@ -1,0 +1,23 @@
+uuid: 7876157e-d562-4e3b-ae6a-9f6ca31b2d2c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meeting_point
+    - node.type.event
+  module:
+    - geofield
+_core:
+  default_config_hash: 1edvfd0JKhjSy-AcrYYkSg1uL6A2YprGeBMtJ4K-OYM
+id: node.event.field_meeting_point
+field_name: field_meeting_point
+entity_type: node
+bundle: event
+label: 'Meeting point'
+description: 'GPS coordinates of the meeting point. Defaults to Vondelpark when the source page does not specify one.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: geofield

--- a/config/sync/field.field.node.event.field_route.yml
+++ b/config/sync/field.field.node.event.field_route.yml
@@ -1,0 +1,31 @@
+uuid: a408b6c9-36f6-4cdf-b8ce-f3fce24c6028
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_route
+    - node.type.event
+    - node.type.route
+_core:
+  default_config_hash: wsHeQhy0dDiIkgEyXKlzAQEVUNviyGRUW56u3Y6Zr_o
+id: node.event.field_route
+field_name: field_route
+entity_type: node
+bundle: event
+label: Route
+description: 'The route being skated. Populated post-import via legacy URL/ID lookup.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      route: route
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.news.field_legacy_id.yml
+++ b/config/sync/field.field.node.news.field_legacy_id.yml
@@ -1,0 +1,21 @@
+uuid: 75fdd1de-65c3-450b-97a0-c2b1182bb2b0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_id
+    - node.type.news
+_core:
+  default_config_hash: zJTopVYiWbCdJyy22rjiUxZ0-tGHYJQBT2lPRv_7peo
+id: node.news.field_legacy_id
+field_name: field_legacy_id
+entity_type: node
+bundle: news
+label: 'Legacy ID'
+description: 'Stable identifier from the legacy v1 site, used for migration map lookup.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.news.field_legacy_url.yml
+++ b/config/sync/field.field.node.news.field_legacy_url.yml
@@ -1,0 +1,25 @@
+uuid: 772435e2-27aa-4caa-b2e7-14e3caf97210
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_url
+    - node.type.news
+  module:
+    - link
+_core:
+  default_config_hash: Wdd-s4285DdkGS-P75tW5291VJCMNs9QI2L6YppKVD8
+id: node.news.field_legacy_url
+field_name: field_legacy_url
+entity_type: node
+bundle: news
+label: 'Legacy URL'
+description: 'Original URL on the legacy v1 site, used for redirect mapping.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/config/sync/field.field.node.page.field_legacy_id.yml
+++ b/config/sync/field.field.node.page.field_legacy_id.yml
@@ -1,0 +1,21 @@
+uuid: 4303fe0a-c860-4123-9db4-8c30dbdf28f4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_id
+    - node.type.page
+_core:
+  default_config_hash: fZLj_8e33Mbk5hjfsPICGNZAh5pAvZgoJkeJjzcn9rY
+id: node.page.field_legacy_id
+field_name: field_legacy_id
+entity_type: node
+bundle: page
+label: 'Legacy ID'
+description: 'Stable identifier from the legacy v1 site, used for migration map lookup.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.page.field_legacy_url.yml
+++ b/config/sync/field.field.node.page.field_legacy_url.yml
@@ -1,0 +1,25 @@
+uuid: 1a76a3fd-5d06-4592-a1d2-8e94568eb45e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_url
+    - node.type.page
+  module:
+    - link
+_core:
+  default_config_hash: JpBnqjwACagOX4e3TZIeX_G2_14JTLoJbsL6GXbOxPg
+id: node.page.field_legacy_url
+field_name: field_legacy_url
+entity_type: node
+bundle: page
+label: 'Legacy URL'
+description: 'Original URL on the legacy v1 site, used for redirect mapping.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/config/sync/field.storage.node.field_event_datetime.yml
+++ b/config/sync/field.storage.node.field_event_datetime.yml
@@ -1,0 +1,22 @@
+uuid: 81bacdbb-ef0c-4948-91f5-e3e93c5a12bc
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+_core:
+  default_config_hash: VUyLJbpi02JnbJkCjnzjiuis8os8kEtFOq5ZRcqxxJQ
+id: node.field_event_datetime
+field_name: field_event_datetime
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_event_status.yml
+++ b/config/sync/field.storage.node.field_event_status.yml
@@ -1,0 +1,32 @@
+uuid: dda43394-482e-4640-80a3-5ff47bc763e2
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+_core:
+  default_config_hash: epwcsaWNGiCWlB49w_4BqHWAFIAhbIRtrAMDqXe8vxs
+id: node.field_event_status
+field_name: field_event_status
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: confirmed
+      label: Confirmed
+    -
+      value: cancelled
+      label: Cancelled
+    -
+      value: tentative
+      label: Tentative
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_meeting_point.yml
+++ b/config/sync/field.storage.node.field_meeting_point.yml
@@ -1,0 +1,22 @@
+uuid: 4a4df126-11ba-4601-b300-1564fa18896d
+langcode: en
+status: true
+dependencies:
+  module:
+    - geofield
+    - node
+_core:
+  default_config_hash: IcPpfKHvjGxaL_wfDUikcAekfzL2JLMW1ZVE4e-EaJ0
+id: node.field_meeting_point
+field_name: field_meeting_point
+entity_type: node
+type: geofield
+settings:
+  backend: geofield_backend_default
+module: geofield
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_route.yml
+++ b/config/sync/field.storage.node.field_route.yml
@@ -1,0 +1,21 @@
+uuid: 53ff2302-06d4-4fcc-a3e4-67852fea1f3a
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+_core:
+  default_config_hash: FIMfsa5Er9r4mHbFffx68vvmsqTSptz2Msalp1IDUt4
+id: node.field_route
+field_name: field_route
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/node.type.event.yml
+++ b/config/sync/node.type.event.yml
@@ -1,0 +1,16 @@
+uuid: 573db288-a008-43b8-b18c-d62fdd84fbbb
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - fns_migrate
+_core:
+  default_config_hash: aeVsVXt0RxZu41x65WKAPA-4RX6eD0YdrGw2F1BU_qQ
+name: 'Skate event'
+type: event
+description: 'A weekly Friday Night Skate event imported from the legacy site. Captures the event date, meeting point, status and the route being skated.'
+help: 'Create a skate event. Set the date and time (Europe/Amsterdam), pick the route, mark the status (confirmed / cancelled / tentative) and provide a hero image.'
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/web/modules/custom/fns_migrate/config/optional/field.field.node.event.field_event_datetime.yml
+++ b/web/modules/custom/fns_migrate/config/optional/field.field.node.event.field_event_datetime.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_datetime
+    - node.type.event
+  module:
+    - datetime
+id: node.event.field_event_datetime
+field_name: field_event_datetime
+entity_type: node
+bundle: event
+label: 'Date and time'
+description: 'Date and time of the skate, in Europe/Amsterdam timezone. Defaults to 20:00 on the configured day.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  datetime_type: datetime
+field_type: datetime

--- a/web/modules/custom/fns_migrate/config/optional/field.field.node.event.field_event_status.yml
+++ b/web/modules/custom/fns_migrate/config/optional/field.field.node.event.field_event_status.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_status
+    - node.type.event
+  module:
+    - options
+id: node.event.field_event_status
+field_name: field_event_status
+entity_type: node
+bundle: event
+label: 'Status'
+description: 'Whether the skate is confirmed, cancelled or still tentative. Reused by the newsletter pipeline.'
+required: true
+translatable: false
+default_value:
+  -
+    value: tentative
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/modules/custom/fns_migrate/config/optional/field.field.node.event.field_hero_image.yml
+++ b/web/modules/custom/fns_migrate/config/optional/field.field.node.event.field_hero_image.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_hero_image
+    - node.type.event
+  module:
+    - media
+id: node.event.field_hero_image
+field_name: field_hero_image
+entity_type: node
+bundle: event
+label: 'Hero image'
+description: 'Hero image for the event, scraped from the legacy site''s og:image meta tag.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/modules/custom/fns_migrate/config/optional/field.field.node.event.field_legacy_id.yml
+++ b/web/modules/custom/fns_migrate/config/optional/field.field.node.event.field_legacy_id.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_id
+    - node.type.event
+id: node.event.field_legacy_id
+field_name: field_legacy_id
+entity_type: node
+bundle: event
+label: 'Legacy ID'
+description: 'Stable identifier from the legacy v1 site, used for migration map lookup.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/modules/custom/fns_migrate/config/optional/field.field.node.event.field_legacy_url.yml
+++ b/web/modules/custom/fns_migrate/config/optional/field.field.node.event.field_legacy_url.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_url
+    - node.type.event
+  module:
+    - link
+id: node.event.field_legacy_url
+field_name: field_legacy_url
+entity_type: node
+bundle: event
+label: 'Legacy URL'
+description: 'Original URL on the legacy v1 site, used for redirect mapping.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/web/modules/custom/fns_migrate/config/optional/field.field.node.event.field_meeting_point.yml
+++ b/web/modules/custom/fns_migrate/config/optional/field.field.node.event.field_meeting_point.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meeting_point
+    - node.type.event
+  module:
+    - geofield
+id: node.event.field_meeting_point
+field_name: field_meeting_point
+entity_type: node
+bundle: event
+label: 'Meeting point'
+description: 'GPS coordinates of the meeting point. Defaults to Vondelpark when the source page does not specify one.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  backend: geofield_backend_default
+field_type: geofield

--- a/web/modules/custom/fns_migrate/config/optional/field.field.node.event.field_route.yml
+++ b/web/modules/custom/fns_migrate/config/optional/field.field.node.event.field_route.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_route
+    - node.type.event
+    - node.type.route
+id: node.event.field_route
+field_name: field_route
+entity_type: node
+bundle: event
+label: 'Route'
+description: 'The route being skated. Populated post-import via legacy URL/ID lookup.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      route: route
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/modules/custom/fns_migrate/config/optional/field.field.node.news.field_legacy_id.yml
+++ b/web/modules/custom/fns_migrate/config/optional/field.field.node.news.field_legacy_id.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_id
+    - node.type.news
+id: node.news.field_legacy_id
+field_name: field_legacy_id
+entity_type: node
+bundle: news
+label: 'Legacy ID'
+description: 'Stable identifier from the legacy v1 site, used for migration map lookup.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/modules/custom/fns_migrate/config/optional/field.field.node.news.field_legacy_url.yml
+++ b/web/modules/custom/fns_migrate/config/optional/field.field.node.news.field_legacy_url.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_url
+    - node.type.news
+  module:
+    - link
+id: node.news.field_legacy_url
+field_name: field_legacy_url
+entity_type: node
+bundle: news
+label: 'Legacy URL'
+description: 'Original URL on the legacy v1 site, used for redirect mapping.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/web/modules/custom/fns_migrate/config/optional/field.field.node.page.field_legacy_id.yml
+++ b/web/modules/custom/fns_migrate/config/optional/field.field.node.page.field_legacy_id.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_id
+    - node.type.page
+id: node.page.field_legacy_id
+field_name: field_legacy_id
+entity_type: node
+bundle: page
+label: 'Legacy ID'
+description: 'Stable identifier from the legacy v1 site, used for migration map lookup.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/modules/custom/fns_migrate/config/optional/field.field.node.page.field_legacy_url.yml
+++ b/web/modules/custom/fns_migrate/config/optional/field.field.node.page.field_legacy_url.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_url
+    - node.type.page
+  module:
+    - link
+id: node.page.field_legacy_url
+field_name: field_legacy_url
+entity_type: node
+bundle: page
+label: 'Legacy URL'
+description: 'Original URL on the legacy v1 site, used for redirect mapping.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/web/modules/custom/fns_migrate/config/optional/field.storage.node.field_event_datetime.yml
+++ b/web/modules/custom/fns_migrate/config/optional/field.storage.node.field_event_datetime.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_event_datetime
+field_name: field_event_datetime
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/fns_migrate/config/optional/field.storage.node.field_event_status.yml
+++ b/web/modules/custom/fns_migrate/config/optional/field.storage.node.field_event_status.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_event_status
+field_name: field_event_status
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: confirmed
+      label: Confirmed
+    -
+      value: cancelled
+      label: Cancelled
+    -
+      value: tentative
+      label: Tentative
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/fns_migrate/config/optional/field.storage.node.field_meeting_point.yml
+++ b/web/modules/custom/fns_migrate/config/optional/field.storage.node.field_meeting_point.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - geofield
+    - node
+id: node.field_meeting_point
+field_name: field_meeting_point
+entity_type: node
+type: geofield
+settings:
+  backend: geofield_backend_default
+module: geofield
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/fns_migrate/config/optional/field.storage.node.field_route.yml
+++ b/web/modules/custom/fns_migrate/config/optional/field.storage.node.field_route.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_route
+field_name: field_route
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/fns_migrate/config/optional/node.type.event.yml
+++ b/web/modules/custom/fns_migrate/config/optional/node.type.event.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - fns_migrate
+name: 'Skate event'
+type: event
+description: 'A weekly Friday Night Skate event imported from the legacy site. Captures the event date, meeting point, status and the route being skated.'
+help: 'Create a skate event. Set the date and time (Europe/Amsterdam), pick the route, mark the status (confirmed / cancelled / tentative) and provide a hero image.'
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/web/modules/custom/fns_migrate/fns_migrate.info.yml
+++ b/web/modules/custom/fns_migrate/fns_migrate.info.yml
@@ -15,6 +15,7 @@ dependencies:
   - drupal:options
   - drupal:link
   - drupal:text
+  - drupal:datetime
   - drupal:path_alias
   - geofield:geofield
   - redirect:redirect

--- a/web/modules/custom/fns_migrate/fns_migrate.install
+++ b/web/modules/custom/fns_migrate/fns_migrate.install
@@ -20,11 +20,6 @@ use Drupal\node\Entity\NodeType;
  * if missing and attach a bundle instance to the route content type.
  */
 function fns_migrate_install(): void {
-  $route = NodeType::load('route');
-  if ($route === NULL) {
-    return;
-  }
-
   // Ensure the shared node.body storage exists.
   $storage = FieldStorageConfig::loadByName('node', 'body');
   if ($storage === NULL) {
@@ -37,12 +32,17 @@ function fns_migrate_install(): void {
     $storage->save();
   }
 
-  // Attach a body instance to the route bundle.
-  $instance = FieldConfig::loadByName('node', 'route', 'body');
-  if ($instance === NULL) {
+  // Attach a body instance to each fns_migrate-shipped bundle that exists.
+  foreach (['route', 'event'] as $bundle) {
+    if (NodeType::load($bundle) === NULL) {
+      continue;
+    }
+    if (FieldConfig::loadByName('node', $bundle, 'body') !== NULL) {
+      continue;
+    }
     FieldConfig::create([
       'field_storage' => $storage,
-      'bundle' => 'route',
+      'bundle' => $bundle,
       'label' => 'Body',
       'settings' => [
         'display_summary' => TRUE,

--- a/web/modules/custom/fns_migrate/tests/src/Kernel/EventContentTypeInstallTest.php
+++ b/web/modules/custom/fns_migrate/tests/src/Kernel/EventContentTypeInstallTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\fns_migrate\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Verifies install-time creation of the event content type.
+ *
+ * Confirms the fns_migrate module creates the event node bundle and all
+ * supporting fields shipped under config/optional/, and that the soft
+ * legacy_url / legacy_id fields are also attachable to the news and page
+ * bundles when they exist.
+ *
+ * @group fns_migrate
+ */
+class EventContentTypeInstallTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'link',
+    'datetime',
+    'file',
+    'image',
+    'media',
+    'taxonomy',
+    'node',
+    'filter',
+    'geofield',
+    'migrate',
+    'migrate_plus',
+    'migrate_tools',
+    'migration_tools',
+    'path_alias',
+    'redirect',
+    'fns_migrate',
+  ];
+
+  /**
+   * Field machine names expected on the event bundle.
+   *
+   * Each entry maps the field name to the expected field type.
+   */
+  protected const EXPECTED_EVENT_FIELDS = [
+    'body' => 'text_with_summary',
+    'field_event_datetime' => 'datetime',
+    'field_meeting_point' => 'geofield',
+    'field_event_status' => 'list_string',
+    'field_route' => 'entity_reference',
+    'field_hero_image' => 'entity_reference',
+    'field_legacy_url' => 'link',
+    'field_legacy_id' => 'string',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('media');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('path_alias');
+    $this->installConfig(['filter', 'node', 'field', 'fns_migrate']);
+    // Kernel tests don't run hook_install automatically; invoke ours so the
+    // shared body field is attached to the route bundle, then attach a body
+    // instance to the event bundle the same way the runtime install would.
+    \Drupal::moduleHandler()->loadInclude('fns_migrate', 'install');
+    fns_migrate_install();
+  }
+
+  /**
+   * The event bundle is created on install.
+   */
+  public function testEventBundleExists(): void {
+    $bundle = NodeType::load('event');
+    $this->assertNotNull($bundle, 'The "event" node type is created on install.');
+    $this->assertSame('Skate event', $bundle->label());
+  }
+
+  /**
+   * Every documented field is present on the event bundle.
+   */
+  public function testAllExpectedFieldsArePresentOnEventBundle(): void {
+    foreach (self::EXPECTED_EVENT_FIELDS as $field_name => $expected_type) {
+      $storage = FieldStorageConfig::loadByName('node', $field_name);
+      $this->assertNotNull(
+        $storage,
+        sprintf('Field storage node.%s is installed.', $field_name)
+      );
+      $this->assertSame(
+        $expected_type,
+        $storage->getType(),
+        sprintf('Field storage node.%s has type %s.', $field_name, $expected_type)
+      );
+
+      $instance = FieldConfig::loadByName('node', 'event', $field_name);
+      $this->assertNotNull(
+        $instance,
+        sprintf('Field instance node.event.%s is installed.', $field_name)
+      );
+      $this->assertSame(
+        $expected_type,
+        $instance->getType(),
+        sprintf('Field instance node.event.%s has type %s.', $field_name, $expected_type)
+      );
+    }
+  }
+
+  /**
+   * Status, route reference and datetime settings match the specification.
+   */
+  public function testEventFieldKeySettings(): void {
+    $status = FieldStorageConfig::loadByName('node', 'field_event_status');
+    $allowed = $status->getSetting('allowed_values');
+    if (is_array($allowed) && array_is_list($allowed) && isset($allowed[0]['value'])) {
+      $values = array_map(static fn(array $v) => (string) $v['value'], $allowed);
+    }
+    else {
+      $values = array_map('strval', array_keys((array) $allowed));
+    }
+    sort($values);
+    $this->assertSame(
+      ['cancelled', 'confirmed', 'tentative'],
+      $values,
+      'Event status allowed values are confirmed/cancelled/tentative.'
+    );
+
+    $datetime = FieldStorageConfig::loadByName('node', 'field_event_datetime');
+    $this->assertSame('datetime', $datetime->getSetting('datetime_type'));
+    $this->assertSame(1, $datetime->getCardinality());
+
+    $route = FieldConfig::loadByName('node', 'event', 'field_route');
+    $this->assertSame('default:node', $route->getSetting('handler'));
+    $handler_settings = $route->getSetting('handler_settings');
+    $this->assertSame(
+      ['route' => 'route'],
+      $handler_settings['target_bundles'] ?? [],
+      'field_route only targets the route bundle.'
+    );
+
+    $datetime_instance = FieldConfig::loadByName('node', 'event', 'field_event_datetime');
+    $this->assertTrue(
+      (bool) $datetime_instance->isRequired(),
+      'field_event_datetime is required on event bundle.'
+    );
+  }
+
+  /**
+   * Optional legacy_url / legacy_id instances attach to news + page bundles.
+   *
+   * Both bundles are created in this test because the drupal_cms_news /
+   * drupal_cms_page recipes are not available in a bare kernel test; the
+   * fns_migrate optional configs should still resolve once those bundles
+   * exist (i.e. when the recipes have been applied at runtime).
+   */
+  public function testLegacyFieldsAttachToNewsAndPageBundles(): void {
+    foreach (['news', 'page'] as $bundle) {
+      NodeType::create(['type' => $bundle, 'name' => ucfirst($bundle)])->save();
+    }
+    /** @var \Drupal\Core\Config\ConfigInstallerInterface $installer */
+    $installer = \Drupal::service('config.installer');
+    $installer->installOptionalConfig();
+
+    foreach (['news', 'page'] as $bundle) {
+      foreach (['field_legacy_url', 'field_legacy_id'] as $field_name) {
+        $instance = FieldConfig::loadByName('node', $bundle, $field_name);
+        $this->assertNotNull(
+          $instance,
+          sprintf(
+            'Field instance node.%s.%s is installed once the bundle exists.',
+            $bundle,
+            $field_name
+          )
+        );
+      }
+    }
+  }
+
+}

--- a/web/modules/custom/fns_migrate/tests/src/Kernel/EventNodeCrudTest.php
+++ b/web/modules/custom/fns_migrate/tests/src/Kernel/EventNodeCrudTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\fns_migrate\Kernel;
+
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Smoke CRUD test for the event content type.
+ *
+ * Creates an event node via the entity API and asserts the datetime field
+ * round-trips through storage and renders in the Europe/Amsterdam timezone
+ * configured in setUp(). Exercised as a kernel test rather than a functional
+ * test because the project's contrib stack (notably canvas/radix) trips the
+ * core install pipeline used by BrowserTestBase; the entity-API path covers
+ * the same content-model contract.
+ *
+ * @group fns_migrate
+ */
+class EventNodeCrudTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'link',
+    'datetime',
+    'file',
+    'image',
+    'media',
+    'taxonomy',
+    'node',
+    'filter',
+    'geofield',
+    'migrate',
+    'migrate_plus',
+    'migrate_tools',
+    'migration_tools',
+    'path_alias',
+    'redirect',
+    'fns_migrate',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('media');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('path_alias');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['filter', 'node', 'field', 'fns_migrate']);
+    \Drupal::moduleHandler()->loadInclude('fns_migrate', 'install');
+    fns_migrate_install();
+
+    $this->config('system.date')
+      ->set('timezone.default', 'Europe/Amsterdam')
+      ->set('timezone.user.configurable', FALSE)
+      ->save();
+  }
+
+  /**
+   * Save an event node and assert its datetime field renders in local time.
+   */
+  public function testCreateEventNodePersistsAndRendersDate(): void {
+    $this->assertNotNull(NodeType::load('event'), 'Event bundle exists.');
+
+    // 24 April 2026 20:00 in Europe/Amsterdam (CEST, UTC+2) == 18:00 UTC.
+    $node = Node::create([
+      'type' => 'event',
+      'title' => 'FNS Friday 24 April 2026',
+      'status' => 1,
+      'field_event_datetime' => '2026-04-24T18:00:00',
+      'field_event_status' => 'confirmed',
+      'field_legacy_id' => '12345',
+      'field_legacy_url' => ['uri' => 'https://fridaynightskate.com/skate/12345'],
+    ]);
+    $node->save();
+
+    $reloaded = Node::load($node->id());
+    $this->assertNotNull($reloaded, 'Event node persists and reloads.');
+    $this->assertSame('FNS Friday 24 April 2026', $reloaded->getTitle());
+    $this->assertSame(
+      'confirmed',
+      $reloaded->get('field_event_status')->value,
+      'Event status round-trips through storage.'
+    );
+    $this->assertSame(
+      '12345',
+      $reloaded->get('field_legacy_id')->value,
+      'Legacy ID round-trips through storage.'
+    );
+
+    $stored = $reloaded->get('field_event_datetime')->value;
+    $this->assertSame('2026-04-24T18:00:00', $stored, 'Datetime is stored as UTC.');
+
+    // Convert the stored UTC value to the site's local timezone and confirm
+    // the human-facing hour is 20:00 local — what the page would render via
+    // the default datetime formatter.
+    $utc = new DrupalDateTime($stored, DateTimeItemInterface::STORAGE_TIMEZONE);
+    $utc->setTimezone(new \DateTimeZone('Europe/Amsterdam'));
+    $this->assertSame(
+      '20:00',
+      $utc->format('H:i'),
+      'Stored UTC datetime renders as 20:00 in Europe/Amsterdam.'
+    );
+
+  }
+
+}


### PR DESCRIPTION
## Issue #130 — Define `event` content type + soft legacy fields on `news` / `page`

Adds the `event` content type and supporting fields used by the Friday Night Skate v2 migration, plus attaches the shared `field_legacy_url` / `field_legacy_id` pair to the existing `news` and `page` bundles so blogger-era URLs and IDs survive the migration cutover.

### Content model

`event` bundle:
- `body` (text_with_summary, attached via `hook_install` from shared core storage)
- `field_event_datetime` (datetime, required)
- `field_event_status` (list_string: `confirmed` / `cancelled` / `tentative`, default `tentative`)
- `field_meeting_point` (geofield, single)
- `field_route` (entity_reference → `node:route`, single)
- `field_hero_image` (reused from #129)
- `field_legacy_url` / `field_legacy_id` (reused from #129)

`news` and `page` bundles:
- `field_legacy_url` / `field_legacy_id` re-used on existing bundles so blogger-era posts and pages keep their source identity.

### Where it ships

- `web/modules/custom/fns_migrate/config/optional/` — all event field storages + instances, the news/page legacy_url/legacy_id instances, and `node.type.event.yml`. Optional config because some bundles (news/page) only exist when DrupalCMS recipes are active.
- `web/modules/custom/fns_migrate/fns_migrate.install` — extended `hook_install` to attach the shared `body` storage to the `event` bundle as well as `route`.

### Tests

- `tests/src/Kernel/EventContentTypeInstallTest.php` — verifies the bundle, every storage + instance, and key settings (datetime required, status allowed_values, route entity_reference target).
- `tests/src/Kernel/EventNodeCrudTest.php` — smoke CRUD test that creates an event node via the entity API and round-trips the datetime field through storage.

### Verification

- `ddev phpunit web/modules/custom/fns_migrate/tests/src/Kernel/` → 8/8 OK, 260 assertions.
- `ddev exec vendor/bin/phpcs --standard=Drupal web/modules/custom/fns_migrate/` → 0 errors, 0 warnings.
- Runtime install verified via `\Drupal::service('config.installer')->installDefaultConfig('module', 'fns_migrate')` followed by `installOptionalConfig()` and the install hook — all expected fields present on `event`, `news`, `page`.
- `ddev drush cex` exported cleanly; only #130-related config drift is included.

### Notes

- PR targets `main` per project guideline. Logically depends on #128 (fns_migrate scaffold) and #129 (route content type) — those PRs' commits are included in this branch's history until they merge.
- Display drift on `core.entity_form_display.node.{news,page}.default.yml` and the news/page view displays is a direct consequence of attaching the new legacy fields and is included in the PR.

Closes #130
