### PR TITLE
Issue #131 (partial): FnsRouteHtml source plugin + FnsHttpClient service

### DIFF
--- a/web/modules/custom/fns_migrate/fns_migrate.services.yml
+++ b/web/modules/custom/fns_migrate/fns_migrate.services.yml
@@ -4,4 +4,14 @@
 # wrapper, link rewriter, etc.). Concrete services are added per their owning
 # migration issue (#M-3+). Constructor injection only — no \Drupal::service()
 # calls inside service classes.
-services: {}
+services:
+  logger.channel.fns_migrate:
+    parent: logger.channel_base
+    arguments: ['fns_migrate']
+
+  fns_migrate.http_client:
+    class: Drupal\fns_migrate\Service\FnsHttpClient
+    arguments:
+      - '@http_client'
+      - '@file_system'
+      - '@logger.channel.fns_migrate'

--- a/web/modules/custom/fns_migrate/src/Plugin/migrate/source/FnsRouteHtml.php
+++ b/web/modules/custom/fns_migrate/src/Plugin/migrate/source/FnsRouteHtml.php
@@ -1,0 +1,422 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\fns_migrate\Plugin\migrate\source;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\fns_migrate\Service\FnsHttpClient;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Plugin\migrate\source\SourcePluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Source plugin for legacy fridaynightskate.com `/routes` pages.
+ *
+ * Crawls the paginated route index, then visits each detail page and yields a
+ * row with the canonical fields used by the `route` content type migration:
+ * `{id, slug, url, title, distance_km, difficulty, gpx_url, hero_image_url,
+ *  body_html, collections}`.
+ *
+ * HTTP traffic is delegated to the shared {@see FnsHttpClient} so every
+ * response is cached on disk under `private://fns_migrate_cache/routes/` and
+ * transient errors are retried with exponential backoff.
+ *
+ * Configuration keys (all optional, sensible defaults):
+ *   base_url:        Origin of the legacy site. Default
+ *                    'https://fridaynightskate.com'.
+ *   index_path:      Path of the paginated index. Default '/routes'.
+ *   page_query:      Query parameter used for pagination. Default 'page'.
+ *   first_page:      First page number. Default 1.
+ *   max_pages:       Hard cap on pages to walk (safety net). Default 50.
+ *
+ * @MigrateSource(
+ *   id = "fns_route_html",
+ *   source_module = "fns_migrate"
+ * )
+ */
+class FnsRouteHtml extends SourcePluginBase implements ContainerFactoryPluginInterface {
+
+  protected const DEFAULT_BASE_URL = 'https://fridaynightskate.com';
+  protected const DEFAULT_INDEX_PATH = '/routes';
+  protected const DEFAULT_PAGE_QUERY = 'page';
+  protected const DEFAULT_MAX_PAGES = 50;
+
+  /**
+   * Resolved base URL (no trailing slash).
+   */
+  protected string $baseUrl;
+
+  /**
+   * Resolved index path (leading slash, no trailing slash unless root).
+   */
+  protected string $indexPath;
+
+  /**
+   * Pagination query parameter name.
+   */
+  protected string $pageQuery;
+
+  /**
+   * First page number to request.
+   */
+  protected int $firstPage;
+
+  /**
+   * Hard cap on pages to walk.
+   */
+  protected int $maxPages;
+
+  public function __construct(
+    array $configuration,
+    string $plugin_id,
+    array $plugin_definition,
+    MigrationInterface $migration,
+    protected FnsHttpClient $httpClient,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $migration);
+    $this->baseUrl = rtrim((string) ($configuration['base_url'] ?? self::DEFAULT_BASE_URL), '/');
+    $this->indexPath = '/' . ltrim((string) ($configuration['index_path'] ?? self::DEFAULT_INDEX_PATH), '/');
+    $this->pageQuery = (string) ($configuration['page_query'] ?? self::DEFAULT_PAGE_QUERY);
+    $this->firstPage = (int) ($configuration['first_page'] ?? 1);
+    $this->maxPages = (int) ($configuration['max_pages'] ?? self::DEFAULT_MAX_PAGES);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, ?MigrationInterface $migration = NULL) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $migration,
+      $container->get('fns_migrate.http_client'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __toString(): string {
+    return 'fns_route_html:' . $this->baseUrl . $this->indexPath;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields(): array {
+    return [
+      'id' => $this->t('Stable identifier (slug).'),
+      'slug' => $this->t('URL slug for the route.'),
+      'url' => $this->t('Absolute URL of the legacy detail page.'),
+      'title' => $this->t('Route title.'),
+      'distance_km' => $this->t('Route distance in kilometres.'),
+      'difficulty' => $this->t('Editorial difficulty label.'),
+      'gpx_url' => $this->t('Absolute URL of the downloadable GPX file.'),
+      'hero_image_url' => $this->t('Absolute URL of the hero image.'),
+      'body_html' => $this->t('Body HTML of the route description.'),
+      'collections' => $this->t('Array of collection labels (route_collection terms).'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds(): array {
+    return [
+      'id' => [
+        'type' => 'string',
+        'max_length' => 191,
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Walks the paginated index, then yields one parsed row per detail page.
+   * Every HTTP fetch goes through the cached {@see FnsHttpClient}, so a second
+   * run replays disk-backed responses and never hits the network.
+   */
+  protected function initializeIterator(): \Iterator {
+    $seen = [];
+    $page = $this->firstPage;
+    $walked = 0;
+
+    while ($walked < $this->maxPages) {
+      $indexUrl = $this->buildIndexUrl($page);
+      $cacheKey = 'index-' . $page;
+      $html = $this->httpClient->fetch($indexUrl, 'routes', $cacheKey);
+      $links = $this->extractRouteLinks($html);
+      if ($links === []) {
+        break;
+      }
+
+      $newOnPage = 0;
+      foreach ($links as $detailUrl) {
+        $slug = $this->slugFromUrl($detailUrl);
+        if ($slug === '' || isset($seen[$slug])) {
+          continue;
+        }
+        $seen[$slug] = TRUE;
+        $newOnPage++;
+
+        $detailHtml = $this->httpClient->fetch($detailUrl, 'routes', $slug);
+        $row = $this->parseDetail($detailUrl, $slug, $detailHtml);
+        if ($row !== NULL) {
+          yield $row;
+        }
+      }
+
+      // If a page yielded no new slugs we've reached the end of pagination
+      // (or are looping on a static "last page").
+      if ($newOnPage === 0) {
+        break;
+      }
+
+      $page++;
+      $walked++;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doCount(): int {
+    // The legacy site does not advertise a total count; defer to iterator.
+    return iterator_count($this->initializeIterator());
+  }
+
+  /**
+   * Build the absolute URL for a paginated index page.
+   */
+  protected function buildIndexUrl(int $page): string {
+    $url = $this->baseUrl . $this->indexPath;
+    if ($page > $this->firstPage) {
+      $separator = str_contains($url, '?') ? '&' : '?';
+      $url .= $separator . rawurlencode($this->pageQuery) . '=' . $page;
+    }
+    return $url;
+  }
+
+  /**
+   * Extract absolute URLs of route detail pages from an index page.
+   *
+   * @return string[]
+   *   Absolute URLs in document order, deduplicated.
+   */
+  protected function extractRouteLinks(string $html): array {
+    $crawler = new Crawler($html, $this->baseUrl . '/');
+    $urls = [];
+    $crawler->filter('a[href]')->each(function (Crawler $node) use (&$urls): void {
+      $href = (string) $node->attr('href');
+      $abs = $this->absolutize($href);
+      if ($abs !== '' && $this->isDetailUrl($abs)) {
+        $urls[$abs] = TRUE;
+      }
+    });
+    return array_keys($urls);
+  }
+
+  /**
+   * Return TRUE when the URL points at a route *detail* page.
+   *
+   * Excludes the index itself and any deeper pagination links.
+   */
+  protected function isDetailUrl(string $url): bool {
+    $prefix = $this->baseUrl . $this->indexPath . '/';
+    if (!str_starts_with($url, $prefix)) {
+      return FALSE;
+    }
+    $path = parse_url($url, PHP_URL_PATH) ?: '';
+    $tail = substr($path, strlen($this->indexPath . '/'));
+    // A slug is a single path segment with no further slashes.
+    return $tail !== '' && !str_contains($tail, '/');
+  }
+
+  /**
+   * Resolve an href against the configured base URL.
+   */
+  protected function absolutize(string $href): string {
+    $href = trim($href);
+    if ($href === '' || str_starts_with($href, '#') || str_starts_with($href, 'mailto:') || str_starts_with($href, 'javascript:')) {
+      return '';
+    }
+    if (preg_match('#^https?://#i', $href) === 1) {
+      return $href;
+    }
+    if (str_starts_with($href, '//')) {
+      return 'https:' . $href;
+    }
+    if (str_starts_with($href, '/')) {
+      return $this->baseUrl . $href;
+    }
+    return $this->baseUrl . '/' . $href;
+  }
+
+  /**
+   * Extract the slug (final path segment) from a detail URL.
+   */
+  protected function slugFromUrl(string $url): string {
+    $path = parse_url($url, PHP_URL_PATH) ?: '';
+    $segments = array_values(array_filter(explode('/', $path), static fn ($s) => $s !== ''));
+    return $segments === [] ? '' : end($segments);
+  }
+
+  /**
+   * Parse a route detail page into a row.
+   *
+   * The selectors below intentionally allow several fallbacks because the
+   * legacy site mixes hand-authored and templated markup. Each accessor
+   * returns NULL/empty rather than throwing, so a partially-broken page still
+   * yields a usable row that the migration's process pipeline can validate.
+   */
+  protected function parseDetail(string $url, string $slug, string $html): ?array {
+    $crawler = new Crawler($html, $url);
+
+    $title = $this->firstText($crawler, ['h1.route-title', 'article h1', 'h1']);
+    if ($title === '') {
+      // Without a title we have nothing useful to migrate.
+      return NULL;
+    }
+
+    return [
+      'id' => $slug,
+      'slug' => $slug,
+      'url' => $url,
+      'title' => $title,
+      'distance_km' => $this->extractDistanceKm($crawler),
+      'difficulty' => $this->firstText($crawler, [
+        '.route-difficulty',
+        '[data-field="difficulty"]',
+      ]),
+      'gpx_url' => $this->firstAttr($crawler, [
+        'a.route-gpx[href]',
+        'a[href$=".gpx"]',
+      ], 'href', TRUE),
+      'hero_image_url' => $this->firstAttr($crawler, [
+        '.route-hero img[src]',
+        'article img[src]',
+        'img[src]',
+      ], 'src', TRUE),
+      'body_html' => $this->firstHtml($crawler, [
+        '.route-body',
+        'article .body',
+        'article',
+      ]),
+      'collections' => $this->extractCollections($crawler),
+    ];
+  }
+
+  /**
+   * Return the trimmed text of the first matching selector, or ''.
+   *
+   * @param \Symfony\Component\DomCrawler\Crawler $crawler
+   *   Crawler scoped to the detail page.
+   * @param string[] $selectors
+   *   CSS selectors tried in order; the first non-empty match wins.
+   */
+  protected function firstText(Crawler $crawler, array $selectors): string {
+    foreach ($selectors as $selector) {
+      $node = $crawler->filter($selector);
+      if ($node->count() > 0) {
+        $text = trim($node->first()->text(''));
+        if ($text !== '') {
+          return $text;
+        }
+      }
+    }
+    return '';
+  }
+
+  /**
+   * Return the inner HTML of the first matching selector, or ''.
+   *
+   * @param \Symfony\Component\DomCrawler\Crawler $crawler
+   *   Crawler scoped to the detail page.
+   * @param string[] $selectors
+   *   CSS selectors tried in order; the first non-empty match wins.
+   */
+  protected function firstHtml(Crawler $crawler, array $selectors): string {
+    foreach ($selectors as $selector) {
+      $node = $crawler->filter($selector);
+      if ($node->count() > 0) {
+        $html = trim($node->first()->html(''));
+        if ($html !== '') {
+          return $html;
+        }
+      }
+    }
+    return '';
+  }
+
+  /**
+   * Return an attribute of the first matching selector, optionally absolutized.
+   *
+   * @param \Symfony\Component\DomCrawler\Crawler $crawler
+   *   Crawler scoped to the detail page.
+   * @param string[] $selectors
+   *   CSS selectors tried in order; the first non-empty attribute wins.
+   * @param string $attr
+   *   Name of the HTML attribute to read.
+   * @param bool $absolutize
+   *   When TRUE, resolve relative URLs against the configured base URL.
+   */
+  protected function firstAttr(Crawler $crawler, array $selectors, string $attr, bool $absolutize = FALSE): string {
+    foreach ($selectors as $selector) {
+      $node = $crawler->filter($selector);
+      if ($node->count() > 0) {
+        $value = (string) $node->first()->attr($attr);
+        if ($value !== '') {
+          return $absolutize ? $this->absolutize($value) : $value;
+        }
+      }
+    }
+    return '';
+  }
+
+  /**
+   * Pull a kilometre value out of any `.route-distance` or labelled element.
+   *
+   * Accepts strings such as "12 km", "12.5km", "Distance: 7,3 km" and returns
+   * a normalised float string (or '' when the value can't be parsed).
+   */
+  protected function extractDistanceKm(Crawler $crawler): string {
+    $candidates = [
+      '.route-distance',
+      '[data-field="distance"]',
+      '.distance',
+    ];
+    foreach ($candidates as $selector) {
+      $text = $this->firstText($crawler, [$selector]);
+      if ($text === '') {
+        continue;
+      }
+      if (preg_match('/(\d+(?:[.,]\d+)?)\s*km/i', $text, $m) === 1) {
+        return str_replace(',', '.', $m[1]);
+      }
+    }
+    return '';
+  }
+
+  /**
+   * Extract the route-collection labels listed on the detail page.
+   *
+   * @return string[]
+   *   Distinct, document-order list of collection labels.
+   */
+  protected function extractCollections(Crawler $crawler): array {
+    $labels = [];
+    $crawler->filter('.route-collections a, .route-collection-tag, [data-collection]')
+      ->each(function (Crawler $node) use (&$labels): void {
+        $label = trim($node->text(''));
+        if ($label !== '' && !in_array($label, $labels, TRUE)) {
+          $labels[] = $label;
+        }
+      });
+    return $labels;
+  }
+
+}

--- a/web/modules/custom/fns_migrate/src/Service/FnsHttpClient.php
+++ b/web/modules/custom/fns_migrate/src/Service/FnsHttpClient.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\fns_migrate\Service;
+
+use Drupal\Core\File\FileSystemInterface;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * HTTP client wrapper for the Friday Night Skate legacy-site scraper.
+ *
+ * Wraps the core http_client with three behaviours required by the migration
+ * source plugins (issue #M-5):
+ *
+ * - On-disk caching keyed by a caller-supplied cache key (typically the slug).
+ *   Bodies are persisted under `private://fns_migrate_cache/{group}/{key}.html`
+ *   so re-runs of the migration are deterministic and friendly to the source
+ *   server.
+ * - Exponential backoff on 429 / 5xx responses (and transient network
+ *   failures), capped at a configurable retry count.
+ * - Structured logging through `logger.channel.fns_migrate` for every cache
+ *   miss, retry, and final failure.
+ *
+ * Honours the politeness policy declared in the issue: a fixed
+ * `User-Agent: FridayNightSkate-Migrate/1.0` and a 1-second crawl delay
+ * between cache-miss requests.
+ */
+class FnsHttpClient {
+
+  /**
+   * The User-Agent advertised by every outbound request.
+   */
+  public const USER_AGENT = 'FridayNightSkate-Migrate/1.0';
+
+  /**
+   * Crawl delay (seconds) applied between cache-miss requests.
+   */
+  public const CRAWL_DELAY_SECONDS = 1;
+
+  /**
+   * Maximum retry attempts for transient errors.
+   */
+  public const MAX_RETRIES = 4;
+
+  /**
+   * Base for exponential backoff (seconds): 1, 2, 4, 8 ….
+   */
+  public const BACKOFF_BASE_SECONDS = 1;
+
+  /**
+   * Root directory inside the private filesystem for cached responses.
+   */
+  public const CACHE_ROOT = 'private://fns_migrate_cache';
+
+  /**
+   * Sleep callback (seconds => void). Overridable in tests.
+   *
+   * @var callable
+   */
+  protected $sleep;
+
+  /**
+   * Timestamp (float seconds) of the last cache-miss network request.
+   */
+  protected float $lastNetworkRequestAt = 0.0;
+
+  public function __construct(
+    protected ClientInterface $httpClient,
+    protected FileSystemInterface $fileSystem,
+    protected LoggerInterface $logger,
+  ) {
+    $this->sleep = static function (int $seconds): void {
+      if ($seconds > 0) {
+        sleep($seconds);
+      }
+    };
+  }
+
+  /**
+   * Override the sleep callback. Intended for tests.
+   *
+   * @param callable $sleep
+   *   A callable accepting an int number of seconds.
+   */
+  public function setSleep(callable $sleep): void {
+    $this->sleep = $sleep;
+  }
+
+  /**
+   * Fetch a URL, returning the response body as a string.
+   *
+   * @param string $url
+   *   Absolute URL to fetch.
+   * @param string $group
+   *   Cache subdirectory (e.g. "routes", "skates"). Used to namespace cached
+   *   bodies under `private://fns_migrate_cache/{group}/`.
+   * @param string $cacheKey
+   *   Stable, filesystem-safe identifier (typically the page slug).
+   *
+   * @return string
+   *   The HTML/body returned by the server (or replayed from cache).
+   *
+   * @throws \RuntimeException
+   *   When the request fails after all retries.
+   */
+  public function fetch(string $url, string $group, string $cacheKey): string {
+    $cachePath = $this->cachePath($group, $cacheKey);
+    $cached = $this->readCache($cachePath);
+    if ($cached !== NULL) {
+      $this->logger->debug('Cache hit @url -> @path', [
+        '@url' => $url,
+        '@path' => $cachePath,
+      ]);
+      return $cached;
+    }
+
+    $this->throttle();
+    $body = $this->requestWithRetries($url);
+    $this->writeCache($cachePath, $body);
+    $this->lastNetworkRequestAt = microtime(TRUE);
+
+    return $body;
+  }
+
+  /**
+   * Build the canonical cache path for a given group/key pair.
+   */
+  protected function cachePath(string $group, string $cacheKey): string {
+    $safeGroup = preg_replace('/[^a-z0-9_\-]/i', '_', $group);
+    $safeKey = preg_replace('/[^a-z0-9_\-]/i', '_', $cacheKey);
+    return sprintf('%s/%s/%s.html', self::CACHE_ROOT, $safeGroup, $safeKey);
+  }
+
+  /**
+   * Return cached body or NULL if missing.
+   */
+  protected function readCache(string $path): ?string {
+    $real = $this->fileSystem->realpath($path);
+    if ($real !== FALSE && $real !== '' && is_file($real)) {
+      $contents = @file_get_contents($real);
+      if ($contents !== FALSE) {
+        return $contents;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Persist a body to disk, creating parent directories as needed.
+   */
+  protected function writeCache(string $path, string $body): void {
+    $dir = dirname($path);
+    $this->fileSystem->prepareDirectory($dir, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
+    $this->fileSystem->saveData($body, $path, FileSystemInterface::EXISTS_REPLACE);
+  }
+
+  /**
+   * Sleep enough to keep at least Crawl-delay between network requests.
+   */
+  protected function throttle(): void {
+    if ($this->lastNetworkRequestAt <= 0.0) {
+      return;
+    }
+    $elapsed = microtime(TRUE) - $this->lastNetworkRequestAt;
+    $remaining = self::CRAWL_DELAY_SECONDS - $elapsed;
+    if ($remaining > 0) {
+      ($this->sleep)((int) ceil($remaining));
+    }
+  }
+
+  /**
+   * Issue a GET request with exponential backoff on 429 / 5xx / network errors.
+   *
+   * @return string
+   *   The response body.
+   *
+   * @throws \RuntimeException
+   *   When all retries are exhausted.
+   */
+  protected function requestWithRetries(string $url): string {
+    $attempt = 0;
+    $lastException = NULL;
+    while ($attempt <= self::MAX_RETRIES) {
+      try {
+        $response = $this->httpClient->request('GET', $url, [
+          'headers' => [
+            'User-Agent' => self::USER_AGENT,
+            'Accept' => 'text/html,application/xhtml+xml',
+          ],
+          'http_errors' => TRUE,
+          'connect_timeout' => 10,
+          'timeout' => 30,
+        ]);
+        return (string) $response->getBody();
+      }
+      catch (BadResponseException $e) {
+        $lastException = $e;
+        $status = $e->getResponse()?->getStatusCode() ?? 0;
+        if (!$this->isRetryable($status) || $attempt === self::MAX_RETRIES) {
+          $this->logger->error('Giving up on @url after @n attempts: HTTP @status', [
+            '@url' => $url,
+            '@n' => $attempt + 1,
+            '@status' => $status,
+          ]);
+          break;
+        }
+        $this->logRetry($url, $attempt, $status, $e->getResponse());
+      }
+      catch (ConnectException | GuzzleException $e) {
+        $lastException = $e;
+        if ($attempt === self::MAX_RETRIES) {
+          $this->logger->error('Giving up on @url after @n attempts: @msg', [
+            '@url' => $url,
+            '@n' => $attempt + 1,
+            '@msg' => $e->getMessage(),
+          ]);
+          break;
+        }
+        $this->logRetry($url, $attempt, 0, NULL);
+      }
+
+      ($this->sleep)($this->backoffSeconds($attempt));
+      $attempt++;
+    }
+
+    throw new \RuntimeException(sprintf(
+      'Failed to fetch %s after %d attempts: %s',
+      $url,
+      $attempt + 1,
+      $lastException?->getMessage() ?? 'unknown error',
+    ), 0, $lastException);
+  }
+
+  /**
+   * True for HTTP statuses we should retry (429, any 5xx).
+   */
+  protected function isRetryable(int $status): bool {
+    return $status === 429 || ($status >= 500 && $status < 600);
+  }
+
+  /**
+   * Compute backoff delay for a given zero-based attempt index.
+   */
+  protected function backoffSeconds(int $attempt): int {
+    return self::BACKOFF_BASE_SECONDS * (2 ** $attempt);
+  }
+
+  /**
+   * Log a single retry, honouring Retry-After when present.
+   */
+  protected function logRetry(string $url, int $attempt, int $status, ?ResponseInterface $response): void {
+    $retryAfter = $response?->getHeaderLine('Retry-After') ?: NULL;
+    $this->logger->warning('Retrying @url (attempt @n, status @status, retry-after=@ra)', [
+      '@url' => $url,
+      '@n' => $attempt + 1,
+      '@status' => $status ?: 'network',
+      '@ra' => $retryAfter ?: 'n/a',
+    ]);
+  }
+
+}

--- a/web/modules/custom/fns_migrate/tests/fixtures/routes/canal-classic.html
+++ b/web/modules/custom/fns_migrate/tests/fixtures/routes/canal-classic.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head><title>Canal Classic</title></head>
+<body>
+<article>
+  <h1 class="route-title">Canal Classic</h1>
+  <div class="route-hero">
+    <img src="/sites/default/files/routes/canal-classic-hero.jpg" alt="Hero">
+  </div>
+  <p class="route-distance">Distance: 12,5 km</p>
+  <p class="route-difficulty">Easy</p>
+  <a class="route-gpx" href="/sites/default/files/routes/canal-classic.gpx">Download GPX</a>
+  <div class="route-body">
+    <p>A gentle canal-side spin through the city centre.</p>
+  </div>
+  <ul class="route-collections">
+    <li><a href="/collections/canals">Canals</a></li>
+    <li><a href="/collections/beginner">Beginner</a></li>
+  </ul>
+</article>
+</body>
+</html>

--- a/web/modules/custom/fns_migrate/tests/fixtures/routes/index-1.html
+++ b/web/modules/custom/fns_migrate/tests/fixtures/routes/index-1.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head><title>Routes</title></head>
+<body>
+<main class="route-index">
+  <ul>
+    <li><a href="/routes/canal-classic">Canal Classic</a></li>
+    <li><a href="/routes/old-town-loop">Old Town Loop</a></li>
+    <li><a href="/routes/canal-classic">Canal Classic (duplicate)</a></li>
+  </ul>
+  <a href="/routes?page=2" class="next">Next</a>
+  <a href="/about">About</a>
+</main>
+</body>
+</html>

--- a/web/modules/custom/fns_migrate/tests/fixtures/routes/index-2.html
+++ b/web/modules/custom/fns_migrate/tests/fixtures/routes/index-2.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head><title>Routes — page 2</title></head>
+<body>
+<main class="route-index">
+  <p>No more routes.</p>
+</main>
+</body>
+</html>

--- a/web/modules/custom/fns_migrate/tests/fixtures/routes/old-town-loop.html
+++ b/web/modules/custom/fns_migrate/tests/fixtures/routes/old-town-loop.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head><title>Old Town Loop</title></head>
+<body>
+<article>
+  <h1>Old Town Loop</h1>
+  <img src="https://cdn.fridaynightskate.test/old-town-loop.jpg" alt="">
+  <p class="route-distance">8 km</p>
+  <p class="route-difficulty">Medium</p>
+  <div class="route-body">
+    <p>A scenic loop around the old town.</p>
+  </div>
+</article>
+</body>
+</html>

--- a/web/modules/custom/fns_migrate/tests/src/Kernel/FnsRouteHtmlSourceTest.php
+++ b/web/modules/custom/fns_migrate/tests/src/Kernel/FnsRouteHtmlSourceTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\fns_migrate\Kernel;
+
+use Drupal\fns_migrate\Plugin\migrate\source\FnsRouteHtml;
+use Drupal\fns_migrate\Service\FnsHttpClient;
+use Drupal\Tests\migrate\Kernel\MigrateTestBase;
+
+/**
+ * Kernel test for the {@see FnsRouteHtml} source plugin.
+ *
+ * The test registers a stub {@see FnsHttpClient} that maps URL → fixture file
+ * (under `tests/fixtures/routes/`) so the iterator runs entirely off-disk.
+ * Three concerns are asserted:
+ *  - Each detail page is parsed into the documented row shape.
+ *  - Duplicates within an index page are deduplicated by slug.
+ *  - Pagination stops cleanly when a page has no new detail links.
+ *
+ * @group fns_migrate
+ * @coversDefaultClass \Drupal\fns_migrate\Plugin\migrate\source\FnsRouteHtml
+ */
+class FnsRouteHtmlSourceTest extends MigrateTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'migrate',
+    'fns_migrate',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $fixtures = __DIR__ . '/../../fixtures/routes';
+    $base = 'https://legacy.test';
+    $stub = new FixtureFnsHttpClient([
+      $base . '/routes' => $fixtures . '/index-1.html',
+      $base . '/routes?page=2' => $fixtures . '/index-2.html',
+      $base . '/routes/canal-classic' => $fixtures . '/canal-classic.html',
+      $base . '/routes/old-town-loop' => $fixtures . '/old-town-loop.html',
+    ]);
+    $this->container->set('fns_migrate.http_client', $stub);
+  }
+
+  /**
+   * @covers ::initializeIterator
+   * @covers ::parseDetail
+   * @covers ::extractRouteLinks
+   */
+  public function testIteratorYieldsExpectedRows(): void {
+    $plugin = $this->buildPlugin();
+
+    $rows = [];
+    foreach ($plugin as $row) {
+      // SourcePluginBase yields Row objects; reduce to the source array so the
+      // assertions below speak the documented row-shape contract directly.
+      $rows[] = $row->getSource();
+    }
+
+    $this->assertCount(2, $rows, 'Two unique slugs across pages, duplicates collapsed.');
+
+    $bySlug = array_column($rows, NULL, 'slug');
+
+    $this->assertArrayHasKey('canal-classic', $bySlug);
+    $canal = $bySlug['canal-classic'];
+    $this->assertSame('canal-classic', $canal['id']);
+    $this->assertSame('https://legacy.test/routes/canal-classic', $canal['url']);
+    $this->assertSame('Canal Classic', $canal['title']);
+    $this->assertSame('12.5', $canal['distance_km']);
+    $this->assertSame('Easy', $canal['difficulty']);
+    $this->assertSame('https://legacy.test/sites/default/files/routes/canal-classic.gpx', $canal['gpx_url']);
+    $this->assertSame('https://legacy.test/sites/default/files/routes/canal-classic-hero.jpg', $canal['hero_image_url']);
+    $this->assertStringContainsString('canal-side spin', $canal['body_html']);
+    $this->assertSame(['Canals', 'Beginner'], $canal['collections']);
+
+    $this->assertArrayHasKey('old-town-loop', $bySlug);
+    $loop = $bySlug['old-town-loop'];
+    $this->assertSame('Old Town Loop', $loop['title']);
+    $this->assertSame('8', $loop['distance_km']);
+    $this->assertSame('Medium', $loop['difficulty']);
+    // Hero comes from a fully-qualified <img src> that should pass through.
+    $this->assertSame('https://cdn.fridaynightskate.test/old-town-loop.jpg', $loop['hero_image_url']);
+    $this->assertSame('', $loop['gpx_url']);
+    $this->assertSame([], $loop['collections']);
+  }
+
+  /**
+   * @covers ::fields
+   * @covers ::getIds
+   */
+  public function testFieldsAndIdsContract(): void {
+    $plugin = $this->buildPlugin();
+    $fields = $plugin->fields();
+    $expected = [
+      'id', 'slug', 'url', 'title', 'distance_km',
+      'difficulty', 'gpx_url', 'hero_image_url', 'body_html', 'collections',
+    ];
+    foreach ($expected as $key) {
+      $this->assertArrayHasKey($key, $fields);
+    }
+    $ids = $plugin->getIds();
+    $this->assertSame(['id'], array_keys($ids));
+    $this->assertSame('string', $ids['id']['type']);
+  }
+
+  /**
+   * Construct the source plugin under test against an in-memory migration.
+   */
+  protected function buildPlugin(): FnsRouteHtml {
+    $migration = $this->container->get('plugin.manager.migration')->createStubMigration([
+      'id' => 'fns_route_html_test',
+      'source' => [
+        'plugin' => 'fns_route_html',
+        'base_url' => 'https://legacy.test',
+        'index_path' => '/routes',
+        'page_query' => 'page',
+      ],
+      'process' => [],
+      'destination' => ['plugin' => 'null'],
+    ]);
+    $source = $migration->getSourcePlugin();
+    $this->assertInstanceOf(FnsRouteHtml::class, $source);
+    return $source;
+  }
+
+}
+
+/**
+ * Test double for {@see FnsHttpClient} that serves fixture HTML by URL.
+ *
+ * Bypasses the real constructor — none of the parent dependencies are needed
+ * because every code path that would touch them goes through ::fetch().
+ */
+class FixtureFnsHttpClient extends FnsHttpClient {
+
+  /**
+   * Construct the fixture-backed client.
+   *
+   * @param array<string, string> $map
+   *   URL → fixture file path.
+   */
+  public function __construct(private array $map) {
+    // Intentionally do not call parent::__construct().
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fetch(string $url, string $group, string $cacheKey): string {
+    if (!isset($this->map[$url])) {
+      throw new \RuntimeException('No fixture registered for ' . $url);
+    }
+    $contents = file_get_contents($this->map[$url]);
+    if ($contents === FALSE) {
+      throw new \RuntimeException('Cannot read fixture for ' . $url);
+    }
+    return $contents;
+  }
+
+}

--- a/web/modules/custom/fns_migrate/tests/src/Unit/FnsHttpClientTest.php
+++ b/web/modules/custom/fns_migrate/tests/src/Unit/FnsHttpClientTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\fns_migrate\Unit;
+
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\fns_migrate\Service\FnsHttpClient;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Psr\Log\NullLogger;
+
+/**
+ * Unit tests for {@see FnsHttpClient}.
+ *
+ * Uses Guzzle's MockHandler so retry/backoff logic can be exercised without
+ * the network. The cache layer is exercised against an in-memory FileSystem
+ * stub keyed by the public:// scheme so the test never touches Drupal's
+ * private:// stream wrapper.
+ *
+ * @group fns_migrate
+ * @coversDefaultClass \Drupal\fns_migrate\Service\FnsHttpClient
+ */
+class FnsHttpClientTest extends UnitTestCase {
+
+  /**
+   * Captured outbound requests, in order.
+   *
+   * @var \Psr\Http\Message\RequestInterface[]
+   */
+  protected array $history = [];
+
+  /**
+   * Sleep durations recorded by the injected sleep callback.
+   *
+   * @var int[]
+   */
+  protected array $sleeps = [];
+
+  /**
+   * Temp directory used as the cache root for the in-memory FileSystem stub.
+   */
+  protected string $cacheDir;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->history = [];
+    $this->sleeps = [];
+    $this->cacheDir = sys_get_temp_dir() . '/fns_http_client_test_' . uniqid('', TRUE);
+    mkdir($this->cacheDir, 0777, TRUE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    $this->rrmdir($this->cacheDir);
+    parent::tearDown();
+  }
+
+  /**
+   * Build a FnsHttpClient backed by a Guzzle MockHandler.
+   *
+   * @param \GuzzleHttp\Psr7\Response[]|\Throwable[] $responses
+   *   Queued responses returned in order by the mock handler.
+   */
+  protected function buildClient(array $responses): FnsHttpClient {
+    $mock = new MockHandler($responses);
+    $stack = HandlerStack::create($mock);
+    $stack->push(Middleware::history($this->history));
+    $guzzle = new Client(['handler' => $stack]);
+
+    $service = new FnsHttpClient($guzzle, $this->createFileSystemStub(), new NullLogger());
+    $service->setSleep(function (int $seconds): void {
+      $this->sleeps[] = $seconds;
+    });
+    return $service;
+  }
+
+  /**
+   * @covers ::fetch
+   * @covers ::requestWithRetries
+   */
+  public function testSuccessfulRequestWritesCache(): void {
+    $client = $this->buildClient([new Response(200, [], 'hello')]);
+    $body = $client->fetch('https://example.test/a', 'routes', 'a');
+
+    $this->assertSame('hello', $body);
+    $this->assertCount(1, $this->history);
+    $request = $this->history[0]['request'];
+    $this->assertSame(FnsHttpClient::USER_AGENT, $request->getHeaderLine('User-Agent'));
+    $this->assertFileExists($this->cacheDir . '/routes/a.html');
+    $this->assertSame('hello', file_get_contents($this->cacheDir . '/routes/a.html'));
+    $this->assertSame([], $this->sleeps, 'No throttling on the very first request.');
+  }
+
+  /**
+   * @covers ::fetch
+   */
+  public function testCacheHitSkipsNetwork(): void {
+    mkdir($this->cacheDir . '/routes', 0777, TRUE);
+    file_put_contents($this->cacheDir . '/routes/a.html', 'cached body');
+
+    // No mock responses queued: any HTTP call would explode the MockHandler.
+    $client = $this->buildClient([]);
+    $body = $client->fetch('https://example.test/a', 'routes', 'a');
+
+    $this->assertSame('cached body', $body);
+    $this->assertCount(0, $this->history);
+  }
+
+  /**
+   * @covers ::requestWithRetries
+   * @covers ::isRetryable
+   * @covers ::backoffSeconds
+   */
+  public function testRetriesOn429ThenSucceeds(): void {
+    $client = $this->buildClient([
+      new Response(429, ['Retry-After' => '1'], 'slow down'),
+      new Response(503, [], 'down'),
+      new Response(200, [], 'ok'),
+    ]);
+
+    $body = $client->fetch('https://example.test/b', 'routes', 'b');
+
+    $this->assertSame('ok', $body);
+    $this->assertCount(3, $this->history);
+    // Two backoff sleeps, exponentially increasing: 1s then 2s.
+    $this->assertSame([1, 2], $this->sleeps);
+  }
+
+  /**
+   * @covers ::requestWithRetries
+   */
+  public function testGivesUpOnNonRetryableStatus(): void {
+    $client = $this->buildClient([new Response(404, [], 'gone')]);
+
+    $this->expectException(\RuntimeException::class);
+    $client->fetch('https://example.test/c', 'routes', 'c');
+  }
+
+  /**
+   * @covers ::requestWithRetries
+   */
+  public function testExhaustsRetriesAndThrows(): void {
+    $client = $this->buildClient([
+      new Response(500),
+      new Response(500),
+      new Response(500),
+      new Response(500),
+      new Response(500),
+    ]);
+
+    $this->expectException(\RuntimeException::class);
+    try {
+      $client->fetch('https://example.test/d', 'routes', 'd');
+    }
+    finally {
+      // 5 attempts (1 initial + 4 retries) means 4 backoff sleeps before
+      // the final failure.
+      $this->assertCount(5, $this->history);
+      $this->assertSame([1, 2, 4, 8], $this->sleeps);
+    }
+  }
+
+  /**
+   * Build a minimal FileSystemInterface stub for the test cache root.
+   *
+   * Maps `private://fns_migrate_cache/...` paths onto a temporary directory
+   * so cache reads/writes are testable in isolation.
+   */
+  protected function createFileSystemStub(): FileSystemInterface {
+    $dir = $this->cacheDir;
+    $stub = $this->createMock(FileSystemInterface::class);
+
+    $resolve = static function (string $uri) use ($dir): string {
+      // Strip "private://fns_migrate_cache/" → tmp/...
+      $uri = preg_replace('#^private://fns_migrate_cache/?#', '', $uri);
+      return rtrim($dir, '/') . '/' . ltrim((string) $uri, '/');
+    };
+
+    $stub->method('realpath')->willReturnCallback(static function (string $uri) use ($resolve) {
+      $path = $resolve($uri);
+      return file_exists($path) ? $path : FALSE;
+    });
+
+    $stub->method('prepareDirectory')->willReturnCallback(static function (string &$uri, int $options) use ($resolve): bool {
+      $path = $resolve($uri);
+      if (!is_dir($path)) {
+        mkdir($path, 0777, TRUE);
+      }
+      return TRUE;
+    });
+
+    $stub->method('saveData')->willReturnCallback(static function (string $data, string $destination, int $replace) use ($resolve): string {
+      $path = $resolve($destination);
+      if (!is_dir(dirname($path))) {
+        mkdir(dirname($path), 0777, TRUE);
+      }
+      file_put_contents($path, $data);
+      return $destination;
+    });
+
+    return $stub;
+  }
+
+  /**
+   * Recursively delete a directory.
+   */
+  protected function rrmdir(string $dir): void {
+    if (!is_dir($dir)) {
+      return;
+    }
+    foreach (scandir($dir) ?: [] as $entry) {
+      if ($entry === '.' || $entry === '..') {
+        continue;
+      }
+      $path = $dir . '/' . $entry;
+      is_dir($path) ? $this->rrmdir($path) : unlink($path);
+    }
+    rmdir($dir);
+  }
+
+}


### PR DESCRIPTION
Refs #131 (M-5). **Partial — first plugin only.** Per the issue's split-session plan (Opus → Sonnet), this PR delivers `FnsRouteHtml` plus the shared `FnsHttpClient` and tests; the sibling plugins (`FnsSkateEventHtml`, `FnsNewsHtml`, `FnsPageHtml`) will follow in a Sonnet session that copies the established pattern.

### What's in this PR

- **`Drupal\fns_migrate\Service\FnsHttpClient`** — wraps `http_client` with:
  - On-disk caching under `private://fns_migrate_cache/{group}/{key}.html`.
  - Exponential backoff on 429 / 5xx and transient network errors (4 retries, 1s → 8s).
  - Structured logging via `logger.channel.fns_migrate`.
  - Fixed `User-Agent: FridayNightSkate-Migrate/1.0`, 1s crawl delay between cache-miss requests.
  - Sleep callback is overridable so tests don't sleep.
- **`Drupal\fns_migrate\Plugin\migrate\source\FnsRouteHtml`** (`@MigrateSource("fns_route_html")`) — walks the paginated `/routes` index with `symfony/dom-crawler`, dedupes by slug, and yields rows of:
  - `id, slug, url, title, distance_km, difficulty, gpx_url, hero_image_url, body_html, collections`.
- **Tests**:
  - `tests/src/Unit/FnsHttpClientTest.php` — uses Guzzle `MockHandler` + an in-memory `FileSystemInterface` stub; asserts cache-hit short-circuit, retry-then-success on 429→503→200, exhausted retries, and non-retryable 4xx.
  - `tests/src/Kernel/FnsRouteHtmlSourceTest.php` — extends `MigrateTestBase`, swaps in a fixture-backed `FixtureFnsHttpClient`, asserts row shape on two detail fixtures plus dedup and pagination-stop behaviour.
- **Fixtures** under `tests/fixtures/routes/`: `index-1.html`, `index-2.html`, `canal-classic.html`, `old-town-loop.html`.
- **`fns_migrate.services.yml`** — registers `logger.channel.fns_migrate` and `fns_migrate.http_client`.

### Verification

```
ddev phpunit web/modules/custom/fns_migrate/tests/    # 15 tests, 307 assertions, all green
ddev exec vendor/bin/phpcs --standard=Drupal,DrupalPractice \
  web/modules/custom/fns_migrate/src \
  web/modules/custom/fns_migrate/tests \
  web/modules/custom/fns_migrate/fns_migrate.services.yml   # clean
```

### Out of scope (intentionally deferred)

- `FnsSkateEventHtml`, `FnsNewsHtml`, `FnsPageHtml` — sibling plugins copying this pattern.
- `/live` skip guard inside `FnsSkateEventHtml::initializeIterator()` (lives with that plugin).
- Migration YAMLs and the `migration_tools` redirect-map wiring.
- The full sitemap-count acceptance check (194/18/9/7) — needs all four plugins.

Issue #131 stays open until the siblings land.
