### PR TITLE
Issue #133: fns_route_collections migration and source plugin

### DIFF
--- a/web/modules/custom/fns_migrate/migrations/fns_route_collections.yml
+++ b/web/modules/custom/fns_migrate/migrations/fns_route_collections.yml
@@ -1,0 +1,21 @@
+id: fns_route_collections
+label: 'FNS: Legacy route collections → taxonomy/route_collection'
+migration_group: fns
+source:
+  plugin: fns_route_collections_html
+  base_url: 'https://fridaynightskate.com'
+  index_path: /routes/collections
+process:
+  vid:
+    plugin: default_value
+    default_value: route_collection
+  name: name
+  description/value: description
+  description/format:
+    plugin: default_value
+    default_value: plain_text
+destination:
+  plugin: 'entity:taxonomy_term'
+migration_dependencies:
+  required: []
+  optional: []

--- a/web/modules/custom/fns_migrate/src/Plugin/migrate/source/FnsRouteCollectionsHtml.php
+++ b/web/modules/custom/fns_migrate/src/Plugin/migrate/source/FnsRouteCollectionsHtml.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\fns_migrate\Plugin\migrate\source;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\fns_migrate\Service\FnsHttpClient;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Plugin\migrate\source\SourcePluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Source plugin for legacy fridaynightskate.com `/routes/collections` page.
+ *
+ * Scrapes the collections index at `/routes/collections`, discovers each
+ * collection's absolute URL, then fetches each detail page to extract the
+ * `<meta name="description">` value. Yields one row per collection:
+ * `{id, slug, url, name, description}`.
+ *
+ * HTTP traffic is delegated to the shared {@see FnsHttpClient} so every
+ * response is cached on disk and transient errors are retried.
+ *
+ * Configuration keys (all optional):
+ *   base_url:      Origin of the legacy site. Default
+ *                  'https://fridaynightskate.com'.
+ *   index_path:    Path of the collections index. Default
+ *                  '/routes/collections'.
+ *
+ * @MigrateSource(
+ *   id = "fns_route_collections_html",
+ *   source_module = "fns_migrate"
+ * )
+ */
+class FnsRouteCollectionsHtml extends SourcePluginBase implements ContainerFactoryPluginInterface {
+
+  protected const DEFAULT_BASE_URL = 'https://fridaynightskate.com';
+  protected const DEFAULT_INDEX_PATH = '/routes/collections';
+
+  /**
+   * Resolved base URL (no trailing slash).
+   */
+  protected string $baseUrl;
+
+  /**
+   * Resolved index path (leading slash).
+   */
+  protected string $indexPath;
+
+  public function __construct(
+    array $configuration,
+    string $plugin_id,
+    array $plugin_definition,
+    MigrationInterface $migration,
+    protected FnsHttpClient $httpClient,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $migration);
+    $this->baseUrl = rtrim((string) ($configuration['base_url'] ?? self::DEFAULT_BASE_URL), '/');
+    $this->indexPath = '/' . ltrim((string) ($configuration['index_path'] ?? self::DEFAULT_INDEX_PATH), '/');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, ?MigrationInterface $migration = NULL) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $migration,
+      $container->get('fns_migrate.http_client'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __toString(): string {
+    return 'fns_route_collections_html:' . $this->baseUrl . $this->indexPath;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields(): array {
+    return [
+      'id'          => $this->t('Stable identifier (slug).'),
+      'slug'        => $this->t('URL slug for the collection.'),
+      'url'         => $this->t('Absolute URL of the legacy collection page.'),
+      'name'        => $this->t('Collection name (h1 on detail page).'),
+      'description' => $this->t('Collection description (meta description on detail page).'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds(): array {
+    return [
+      'id' => [
+        'type'       => 'string',
+        'max_length' => 191,
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function initializeIterator(): \Iterator {
+    $indexUrl = $this->baseUrl . $this->indexPath;
+    $indexHtml = $this->httpClient->fetch($indexUrl, 'route_collections', 'index');
+    $collectionUrls = $this->extractCollectionUrls($indexHtml);
+
+    foreach ($collectionUrls as $url) {
+      $slug = $this->slugFromUrl($url);
+      if ($slug === '') {
+        continue;
+      }
+      $detailHtml = $this->httpClient->fetch($url, 'route_collections', $slug);
+      $row = $this->parseDetail($url, $slug, $detailHtml);
+      if ($row !== NULL) {
+        yield $row;
+      }
+    }
+  }
+
+  /**
+   * Extract absolute collection URLs from the index page.
+   *
+   * @return string[]
+   *   Absolute URLs in document order, deduplicated.
+   */
+  protected function extractCollectionUrls(string $html): array {
+    $crawler = new Crawler($html, $this->baseUrl . '/');
+    $prefix = $this->baseUrl . $this->indexPath . '/';
+    $urls = [];
+    $crawler->filter('a[href]')->each(function (Crawler $node) use (&$urls, $prefix): void {
+      $href = trim((string) $node->attr('href'));
+      // Absolutize protocol-relative or root-relative hrefs.
+      if (str_starts_with($href, '//')) {
+        $href = 'https:' . $href;
+      }
+      elseif (str_starts_with($href, '/')) {
+        $href = $this->baseUrl . $href;
+      }
+      if (str_starts_with($href, $prefix)) {
+        $tail = substr(parse_url($href, PHP_URL_PATH) ?: '', strlen($this->indexPath . '/'));
+        // Only single-segment slugs (no further slashes).
+        if ($tail !== '' && !str_contains($tail, '/')) {
+          $urls[$href] = TRUE;
+        }
+      }
+    });
+    return array_keys($urls);
+  }
+
+  /**
+   * Extract the slug (final path segment) from a collection URL.
+   */
+  protected function slugFromUrl(string $url): string {
+    $path = parse_url($url, PHP_URL_PATH) ?: '';
+    $segments = array_values(array_filter(explode('/', $path), static fn ($s) => $s !== ''));
+    return $segments === [] ? '' : end($segments);
+  }
+
+  /**
+   * Parse a collection detail page into a row array.
+   */
+  protected function parseDetail(string $url, string $slug, string $html): ?array {
+    $crawler = new Crawler($html, $url);
+
+    $name = '';
+    $h1 = $crawler->filter('h1');
+    if ($h1->count() > 0) {
+      $name = trim($h1->first()->text(''));
+    }
+    if ($name === '') {
+      return NULL;
+    }
+
+    $description = '';
+    $meta = $crawler->filter('meta[name="description"]');
+    if ($meta->count() > 0) {
+      $description = html_entity_decode(trim((string) $meta->first()->attr('content')), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    }
+
+    return [
+      'id'          => $slug,
+      'slug'        => $slug,
+      'url'         => $url,
+      'name'        => $name,
+      'description' => $description,
+    ];
+  }
+
+}

--- a/web/modules/custom/fns_migrate/tests/fixtures/route_collections/OldSite.html
+++ b/web/modules/custom/fns_migrate/tests/fixtures/route_collections/OldSite.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="This page with skate tracks in &amp; around Amsterdam is a result of enthusiastic skaters who have shared their route for this FNS skate track page.">
+  <title>Skate routes through amsterdam</title>
+</head>
+<body>
+<h1>Skate routes through amsterdam</h1>
+<p>30 routes in this collection.</p>
+</body>
+</html>

--- a/web/modules/custom/fns_migrate/tests/fixtures/route_collections/fns.html
+++ b/web/modules/custom/fns_migrate/tests/fixtures/route_collections/fns.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="This is the largest collection of FNS Skate routes, dating back to the year 2008">
+  <title>Friday Night Skate routes</title>
+</head>
+<body>
+<h1>Friday Night Skate routes</h1>
+<p>123 routes in this collection.</p>
+</body>
+</html>

--- a/web/modules/custom/fns_migrate/tests/fixtures/route_collections/index.html
+++ b/web/modules/custom/fns_migrate/tests/fixtures/route_collections/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Route Collections</title></head>
+<body>
+<p class="text-dark-400 mb-8">Routes grouped by event or theme.</p>
+<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+  <a href="https://legacy.test/routes/collections/fns"
+     class="bg-dark-900 border border-dark-800 rounded-xl overflow-hidden hover:border-fns-600/50 transition group block">
+    <img src="/storage/collections/fns.png" alt="Friday Night Skate routes" loading="lazy">
+    <div class="block p-5">
+      <h2 class="font-bold text-white group-hover:text-fns-400 transition">Friday Night Skate routes</h2>
+      <p class="text-sm text-dark-400 mt-1">123 routes</p>
+    </div>
+  </a>
+  <a href="https://legacy.test/routes/collections/sunday-morning-skate"
+     class="bg-dark-900 border border-dark-800 rounded-xl overflow-hidden hover:border-fns-600/50 transition group block">
+    <img src="/storage/collections/sms.png" alt="Sunday Morning Skate routes" loading="lazy">
+    <div class="block p-5">
+      <h2 class="font-bold text-white group-hover:text-fns-400 transition">Sunday Morning Skate routes</h2>
+      <p class="text-sm text-dark-400 mt-1">45 routes</p>
+    </div>
+  </a>
+  <a href="https://legacy.test/routes/collections/OldSite"
+     class="bg-dark-900 border border-dark-800 rounded-xl overflow-hidden hover:border-fns-600/50 transition group block">
+    <img src="/storage/collections/oldsite.png" alt="Skate routes through amsterdam" loading="lazy">
+    <div class="block p-5">
+      <h2 class="font-bold text-white group-hover:text-fns-400 transition">Skate routes through amsterdam</h2>
+      <p class="text-sm text-dark-400 mt-1">30 routes</p>
+    </div>
+  </a>
+</div>
+</body>
+</html>

--- a/web/modules/custom/fns_migrate/tests/fixtures/route_collections/sunday-morning-skate.html
+++ b/web/modules/custom/fns_migrate/tests/fixtures/route_collections/sunday-morning-skate.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="SMS routes - longer Sunday-morning skate tours, often 40+ km. The Sunday Morning Skate sticks to the smoothest tarmac so you can roll in real comfort.">
+  <title>Sunday Morning Skate routes</title>
+</head>
+<body>
+<h1>Sunday Morning Skate routes</h1>
+<p>45 routes in this collection.</p>
+</body>
+</html>

--- a/web/modules/custom/fns_migrate/tests/src/Kernel/FnsRouteCollectionsHtmlSourceTest.php
+++ b/web/modules/custom/fns_migrate/tests/src/Kernel/FnsRouteCollectionsHtmlSourceTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\fns_migrate\Kernel;
+
+use Drupal\fns_migrate\Plugin\migrate\source\FnsRouteCollectionsHtml;
+use Drupal\fns_migrate\Service\FnsHttpClient;
+use Drupal\Tests\migrate\Kernel\MigrateTestBase;
+
+/**
+ * Kernel test for the {@see FnsRouteCollectionsHtml} source plugin.
+ *
+ * A stub {@see FnsHttpClient} maps each URL to a fixture file under
+ * `tests/fixtures/route_collections/` so the iterator runs entirely off-disk.
+ *
+ * Asserts:
+ *  - All 3 collection rows are yielded with the correct shape.
+ *  - The `id` field equals the URL slug.
+ *  - HTML entities in the description meta tag are decoded.
+ *
+ * @group fns_migrate
+ * @coversDefaultClass \Drupal\fns_migrate\Plugin\migrate\source\FnsRouteCollectionsHtml
+ */
+class FnsRouteCollectionsHtmlSourceTest extends MigrateTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'migrate',
+    'fns_migrate',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $fixtures = __DIR__ . '/../../fixtures/route_collections';
+    $base = 'https://legacy.test';
+    $stub = new FixtureFnsHttpClientForCollections([
+      $base . '/routes/collections'                        => $fixtures . '/index.html',
+      $base . '/routes/collections/fns'                   => $fixtures . '/fns.html',
+      $base . '/routes/collections/sunday-morning-skate'  => $fixtures . '/sunday-morning-skate.html',
+      $base . '/routes/collections/OldSite'               => $fixtures . '/OldSite.html',
+    ]);
+    $this->container->set('fns_migrate.http_client', $stub);
+  }
+
+  /**
+   * @covers ::initializeIterator
+   * @covers ::parseDetail
+   * @covers ::extractCollectionUrls
+   */
+  public function testIteratorYieldsAllThreeCollections(): void {
+    $plugin = $this->buildPlugin();
+
+    $rows = [];
+    foreach ($plugin as $row) {
+      $rows[] = $row->getSource();
+    }
+
+    $this->assertCount(3, $rows, 'Exactly 3 collection rows yielded.');
+
+    $bySlug = array_column($rows, NULL, 'slug');
+
+    // --- fns ---
+    $this->assertArrayHasKey('fns', $bySlug);
+    $fns = $bySlug['fns'];
+    $this->assertSame('fns', $fns['id']);
+    $this->assertSame('https://legacy.test/routes/collections/fns', $fns['url']);
+    $this->assertSame('Friday Night Skate routes', $fns['name']);
+    $this->assertSame(
+      'This is the largest collection of FNS Skate routes, dating back to the year 2008',
+      $fns['description'],
+    );
+
+    // --- sunday-morning-skate ---
+    $this->assertArrayHasKey('sunday-morning-skate', $bySlug);
+    $sms = $bySlug['sunday-morning-skate'];
+    $this->assertSame('sunday-morning-skate', $sms['id']);
+    $this->assertSame('Sunday Morning Skate routes', $sms['name']);
+    $this->assertStringContainsString('40+ km', $sms['description']);
+
+    // --- OldSite ---
+    $this->assertArrayHasKey('OldSite', $bySlug);
+    $old = $bySlug['OldSite'];
+    $this->assertSame('OldSite', $old['id']);
+    $this->assertSame('Skate routes through amsterdam', $old['name']);
+    // HTML entity &amp; in the fixture must be decoded to a plain ampersand.
+    $this->assertStringContainsString('&', $old['description']);
+    $this->assertStringNotContainsString('&amp;', $old['description']);
+  }
+
+  /**
+   * @covers ::fields
+   * @covers ::getIds
+   */
+  public function testFieldsAndIdsContract(): void {
+    $plugin = $this->buildPlugin();
+
+    $fields = $plugin->fields();
+    foreach (['id', 'slug', 'url', 'name', 'description'] as $key) {
+      $this->assertArrayHasKey($key, $fields);
+    }
+
+    $ids = $plugin->getIds();
+    $this->assertSame(['id'], array_keys($ids));
+    $this->assertSame('string', $ids['id']['type']);
+  }
+
+  /**
+   * Construct the source plugin under test against an in-memory migration.
+   */
+  protected function buildPlugin(): FnsRouteCollectionsHtml {
+    $migration = $this->container->get('plugin.manager.migration')->createStubMigration([
+      'id'          => 'fns_route_collections_html_test',
+      'source'      => [
+        'plugin'     => 'fns_route_collections_html',
+        'base_url'   => 'https://legacy.test',
+        'index_path' => '/routes/collections',
+      ],
+      'process'     => [],
+      'destination' => ['plugin' => 'null'],
+    ]);
+    $source = $migration->getSourcePlugin();
+    $this->assertInstanceOf(FnsRouteCollectionsHtml::class, $source);
+    return $source;
+  }
+
+}
+
+/**
+ * Test double for FnsHttpClient that serves fixture HTML by URL.
+ *
+ * Used exclusively by {@see FnsRouteCollectionsHtmlSourceTest}.
+ */
+class FixtureFnsHttpClientForCollections extends FnsHttpClient {
+
+  /**
+   * Constructs the fixture-backed client.
+   *
+   * @param array<string, string> $map
+   *   URL → fixture file path.
+   */
+  public function __construct(private array $map) {
+    // Intentionally do not call parent::__construct().
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fetch(string $url, string $group, string $cacheKey): string {
+    if (!isset($this->map[$url])) {
+      throw new \RuntimeException('No fixture registered for ' . $url);
+    }
+    $contents = file_get_contents($this->map[$url]);
+    if ($contents === FALSE) {
+      throw new \RuntimeException('Cannot read fixture for ' . $url);
+    }
+    return $contents;
+  }
+
+}


### PR DESCRIPTION
Closes #133

## What
- **FnsRouteCollectionsHtml** source plugin (`fns_route_collections_html`) scrapes `/routes/collections` index, discovers the 3 collection URLs, fetches each detail page, and yields rows with `id`, `slug`, `url`, `name`, `description`.
- **fns_route_collections.yml** migration maps rows to `entity:taxonomy_term` in the `route_collection` vocabulary.
- **Kernel test** (FnsRouteCollectionsHtmlSourceTest) with fixture HTML for all 3 collections — 2 tests, 24 assertions, all green.
- PHPCS clean (Drupal, DrupalPractice).

## Acceptance criteria
- `ddev drush mim fns_route_collections` imports exactly 3 terms.
- `ddev drush mr fns_route_collections` rolls back cleanly to 0 terms.