### PR TITLE
Issue #135: fns_skate_events + fns_news + fns_pages migrations

### DIFF
--- a/web/modules/custom/fns_migrate/fns_migrate.install
+++ b/web/modules/custom/fns_migrate/fns_migrate.install
@@ -33,7 +33,7 @@ function fns_migrate_install(): void {
   }
 
   // Attach a body instance to each fns_migrate-shipped bundle that exists.
-  foreach (['route', 'event'] as $bundle) {
+  foreach (['route', 'event', 'news', 'page'] as $bundle) {
     if (NodeType::load($bundle) === NULL) {
       continue;
     }

--- a/web/modules/custom/fns_migrate/migrations/fns_news.yml
+++ b/web/modules/custom/fns_migrate/migrations/fns_news.yml
@@ -1,7 +1,6 @@
 id: fns_news
 label: 'FNS: Legacy news → node/news'
 migration_group: fns
-
 source:
   plugin: fns_news_html
   base_url: 'https://fridaynightskate.com'
@@ -9,20 +8,19 @@ source:
   page_query: page
   first_page: 1
   max_pages: 50
-
 process:
   title: title
   field_legacy_id: id
   field_legacy_url: url
-  body/value: body_html
+  body/value:
+    plugin: absolute_url_to_internal
+    source: body_html
   body/format:
     plugin: default_value
     default_value: basic_html
-
 destination:
   plugin: entity:node
   default_bundle: news
-
 migration_dependencies:
   required: []
   optional: []

--- a/web/modules/custom/fns_migrate/migrations/fns_page.yml
+++ b/web/modules/custom/fns_migrate/migrations/fns_page.yml
@@ -1,7 +1,6 @@
 id: fns_page
 label: 'FNS: Legacy pages → node/page'
 migration_group: fns
-
 source:
   plugin: fns_page_html
   base_url: 'https://fridaynightskate.com'
@@ -9,20 +8,19 @@ source:
   page_query: page
   first_page: 1
   max_pages: 50
-
 process:
   title: title
   field_legacy_id: id
   field_legacy_url: url
-  body/value: body_html
+  body/value:
+    plugin: absolute_url_to_internal
+    source: body_html
   body/format:
     plugin: default_value
     default_value: basic_html
-
 destination:
   plugin: entity:node
   default_bundle: page
-
 migration_dependencies:
   required: []
   optional: []

--- a/web/modules/custom/fns_migrate/migrations/fns_skate_event.yml
+++ b/web/modules/custom/fns_migrate/migrations/fns_skate_event.yml
@@ -1,7 +1,6 @@
 id: fns_skate_event
 label: 'FNS: Legacy skate events → node/event'
 migration_group: fns
-
 source:
   plugin: fns_skate_event_html
   base_url: 'https://fridaynightskate.com'
@@ -9,22 +8,25 @@ source:
   page_query: page
   first_page: 1
   max_pages: 50
-
 process:
   title: title
   field_legacy_id: id
   field_legacy_url: url
   field_event_datetime/value: event_date
-  body/value: body_html
+  body/value:
+    plugin: absolute_url_to_internal
+    source: body_html
   body/format:
     plugin: default_value
     default_value: basic_html
-
+  field_meeting_point: meeting_point
+  field_route/target_id:
+    plugin: fns_route_slug_lookup
+    source: route_slug
 destination:
   plugin: entity:node
   default_bundle: event
-
 migration_dependencies:
   required: []
   optional:
-    - fns_route
+    - fns_routes

--- a/web/modules/custom/fns_migrate/tests/src/Kernel/FnsNewsMigrateTest.php
+++ b/web/modules/custom/fns_migrate/tests/src/Kernel/FnsNewsMigrateTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\fns_migrate\Kernel;
+
+use Drupal\fns_migrate\Service\FnsHttpClient;
+use Drupal\node\Entity\Node;
+use Drupal\Tests\migrate\Kernel\MigrateTestBase;
+
+/**
+ * End-to-end migration test for the fns_news migration.
+ *
+ * Runs the full migration pipeline against fixture HTML files and asserts
+ * that news nodes are created with the correct field values. The stub
+ * HTTP client serves fixture files from `tests/fixtures/news/` so no
+ * network traffic occurs.
+ *
+ * @group fns_migrate
+ */
+class FnsNewsMigrateTest extends MigrateTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'link',
+    'datetime',
+    'file',
+    'image',
+    'media',
+    'taxonomy',
+    'node',
+    'filter',
+    'geofield',
+    'migrate',
+    'migrate_plus',
+    'path_alias',
+    'fns_migrate',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('media');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('path_alias');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['filter', 'node', 'field', 'fns_migrate']);
+
+    \Drupal::moduleHandler()->loadInclude('fns_migrate', 'install');
+    fns_migrate_install();
+
+
+    $fixtures = __DIR__ . '/../../fixtures/news';
+    $base = 'https://legacy.test';
+    $stub = new FixtureNewsExecuteHttpClient([
+      $base . '/news'         => $fixtures . '/index-1.html',
+      $base . '/news?page=2'  => $fixtures . '/index-2.html',
+      $base . '/news/summer-skate-season-2024'        => $fixtures . '/summer-skate-season-2024.html',
+      $base . '/news/new-route-added-regents-canal'   => $fixtures . '/new-route-added-regents-canal.html',
+    ]);
+    $this->container->set('fns_migrate.http_client', $stub);
+  }
+
+  /**
+   * Running fns_news creates news nodes with correct field values.
+   */
+  public function testMigrationCreatesNewsNodes(): void {
+    $migration = $this->getMigration('fns_news');
+    $source = $migration->getSourceConfiguration();
+    $source['base_url'] = 'https://legacy.test';
+    $migration->set('source', $source);
+    $this->executeMigration($migration);
+
+    $nids = \Drupal::entityQuery('node')
+      ->condition('type', 'news')
+      ->accessCheck(FALSE)
+      ->execute();
+
+    // Two unique slugs from the fixtures (duplicate deduplicated).
+    $this->assertCount(2, $nids, 'Two news nodes created.');
+
+    $nodes = Node::loadMultiple($nids);
+    $byTitle = [];
+    foreach ($nodes as $node) {
+      $byTitle[$node->getTitle()] = $node;
+    }
+
+    $this->assertArrayHasKey('Summer Skate Season 2024', $byTitle);
+    $this->assertArrayHasKey("New Route Added: Regent's Canal", $byTitle);
+  }
+
+}
+
+/**
+ * Test double for {@see FnsHttpClient} that serves fixture HTML by URL.
+ */
+class FixtureNewsExecuteHttpClient extends FnsHttpClient {
+
+  /**
+   * Construct the fixture-backed client.
+   *
+   * @param array<string, string> $map
+   *   URL → fixture file path.
+   */
+  public function __construct(private array $map) {
+    // Intentionally do not call parent::__construct().
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fetch(string $url, string $group, string $cacheKey): string {
+    if (!isset($this->map[$url])) {
+      throw new \RuntimeException('No fixture registered for ' . $url);
+    }
+    $contents = file_get_contents($this->map[$url]);
+    if ($contents === FALSE) {
+      throw new \RuntimeException('Cannot read fixture for ' . $url);
+    }
+    return $contents;
+  }
+
+}

--- a/web/modules/custom/fns_migrate/tests/src/Kernel/FnsPageMigrateTest.php
+++ b/web/modules/custom/fns_migrate/tests/src/Kernel/FnsPageMigrateTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\fns_migrate\Kernel;
+
+use Drupal\fns_migrate\Service\FnsHttpClient;
+use Drupal\node\Entity\Node;
+use Drupal\Tests\migrate\Kernel\MigrateTestBase;
+
+/**
+ * End-to-end migration test for the fns_page migration.
+ *
+ * Runs the full migration pipeline against fixture HTML files and asserts
+ * that page nodes are created with the correct field values. The stub
+ * HTTP client serves fixture files from `tests/fixtures/pages/` so no
+ * network traffic occurs.
+ *
+ * @group fns_migrate
+ */
+class FnsPageMigrateTest extends MigrateTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'link',
+    'datetime',
+    'file',
+    'image',
+    'media',
+    'taxonomy',
+    'node',
+    'filter',
+    'geofield',
+    'migrate',
+    'migrate_plus',
+    'path_alias',
+    'fns_migrate',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('media');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('path_alias');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['filter', 'node', 'field', 'fns_migrate']);
+
+    \Drupal::moduleHandler()->loadInclude('fns_migrate', 'install');
+    fns_migrate_install();
+
+    $fixtures = __DIR__ . '/../../fixtures/pages';
+    $base = 'https://legacy.test';
+    $stub = new FixturePageExecuteHttpClient([
+      $base . '/pages'          => $fixtures . '/index-1.html',
+      $base . '/pages?page=2'   => $fixtures . '/index-2.html',
+      $base . '/pages/about'        => $fixtures . '/about.html',
+      $base . '/pages/safety-guide' => $fixtures . '/safety-guide.html',
+    ]);
+    $this->container->set('fns_migrate.http_client', $stub);
+  }
+
+  /**
+   * Running fns_page creates page nodes with correct field values.
+   */
+  public function testMigrationCreatesPageNodes(): void {
+    $migration = $this->getMigration('fns_page');
+    $source = $migration->getSourceConfiguration();
+    $source['base_url'] = 'https://legacy.test';
+    $migration->set('source', $source);
+    $this->executeMigration($migration);
+
+    $nids = \Drupal::entityQuery('node')
+      ->condition('type', 'page')
+      ->accessCheck(FALSE)
+      ->execute();
+
+    // Two unique slugs from the fixtures (duplicate deduplicated).
+    $this->assertCount(2, $nids, 'Two page nodes created.');
+
+    $nodes = Node::loadMultiple($nids);
+    $byTitle = [];
+    foreach ($nodes as $node) {
+      $byTitle[$node->getTitle()] = $node;
+    }
+
+    $this->assertArrayHasKey('About Friday Night Skate', $byTitle);
+    $this->assertArrayHasKey('Safety Guide', $byTitle);
+  }
+
+}
+
+/**
+ * Test double for {@see FnsHttpClient} that serves fixture HTML by URL.
+ */
+class FixturePageExecuteHttpClient extends FnsHttpClient {
+
+  /**
+   * Construct the fixture-backed client.
+   *
+   * @param array<string, string> $map
+   *   URL → fixture file path.
+   */
+  public function __construct(private array $map) {
+    // Intentionally do not call parent::__construct().
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fetch(string $url, string $group, string $cacheKey): string {
+    if (!isset($this->map[$url])) {
+      throw new \RuntimeException('No fixture registered for ' . $url);
+    }
+    $contents = file_get_contents($this->map[$url]);
+    if ($contents === FALSE) {
+      throw new \RuntimeException('Cannot read fixture for ' . $url);
+    }
+    return $contents;
+  }
+
+}

--- a/web/modules/custom/fns_migrate/tests/src/Kernel/FnsSkateEventMigrateTest.php
+++ b/web/modules/custom/fns_migrate/tests/src/Kernel/FnsSkateEventMigrateTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\fns_migrate\Kernel;
+
+use Drupal\fns_migrate\Service\FnsHttpClient;
+use Drupal\node\Entity\Node;
+use Drupal\Tests\migrate\Kernel\MigrateTestBase;
+
+/**
+ * End-to-end migration test for the fns_skate_event migration.
+ *
+ * Runs the full migration pipeline against fixture HTML files and asserts
+ * that event nodes are created with the correct field values. The stub
+ * HTTP client serves fixture files from `tests/fixtures/skates/` so no
+ * network traffic occurs.
+ *
+ * @group fns_migrate
+ */
+class FnsSkateEventMigrateTest extends MigrateTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'options',
+    'link',
+    'datetime',
+    'file',
+    'image',
+    'media',
+    'taxonomy',
+    'node',
+    'filter',
+    'geofield',
+    'migrate',
+    'migrate_plus',
+    'path_alias',
+    'fns_migrate',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('media');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('path_alias');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['filter', 'node', 'field', 'fns_migrate']);
+
+    \Drupal::moduleHandler()->loadInclude('fns_migrate', 'install');
+    fns_migrate_install();
+
+    $fixtures = __DIR__ . '/../../fixtures/skates';
+    $base = 'https://legacy.test';
+    $stub = new FixtureSkateEventHttpClient([
+      $base . '/skate'          => $fixtures . '/index-1.html',
+      $base . '/skate?page=2'   => $fixtures . '/index-2.html',
+      $base . '/skate/friday-night-canal-run'   => $fixtures . '/friday-night-canal-run.html',
+      $base . '/skate/old-town-evening-skate'   => $fixtures . '/old-town-evening-skate.html',
+    ]);
+    $this->container->set('fns_migrate.http_client', $stub);
+  }
+
+  /**
+   * Running fns_skate_event creates event nodes with correct field values.
+   */
+  public function testMigrationCreatesEventNodes(): void {
+    $migration = $this->getMigration('fns_skate_event');
+    $source = $migration->getSourceConfiguration();
+    $source['base_url'] = 'https://legacy.test';
+    $migration->set('source', $source);
+    $this->executeMigration($migration);
+
+    $nids = \Drupal::entityQuery('node')
+      ->condition('type', 'event')
+      ->accessCheck(FALSE)
+      ->execute();
+
+    // Two unique slugs from the fixtures (duplicate + /live URL are skipped).
+    $this->assertCount(2, $nids, 'Two event nodes created.');
+
+    $nodes = Node::loadMultiple($nids);
+    $byTitle = [];
+    foreach ($nodes as $node) {
+      $byTitle[$node->getTitle()] = $node;
+    }
+
+    $this->assertArrayHasKey('Friday Night Canal Run', $byTitle);
+    $canal = $byTitle['Friday Night Canal Run'];
+    $this->assertSame('2024-06-07', $canal->get('field_event_datetime')->value);
+    $this->assertStringContainsString('canal towpath', $canal->get('body')->value);
+
+    $this->assertArrayHasKey('Old Town Evening Skate', $byTitle);
+    $old = $byTitle['Old Town Evening Skate'];
+    $this->assertSame('2024-07-12', $old->get('field_event_datetime')->value);
+  }
+
+}
+
+/**
+ * Test double for {@see FnsHttpClient} that serves fixture HTML by URL.
+ */
+class FixtureSkateEventHttpClient extends FnsHttpClient {
+
+  /**
+   * Construct the fixture-backed client.
+   *
+   * @param array<string, string> $map
+   *   URL → fixture file path.
+   */
+  public function __construct(private array $map) {
+    // Intentionally do not call parent::__construct().
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fetch(string $url, string $group, string $cacheKey): string {
+    if (!isset($this->map[$url])) {
+      throw new \RuntimeException('No fixture registered for ' . $url);
+    }
+    $contents = file_get_contents($this->map[$url]);
+    if ($contents === FALSE) {
+      throw new \RuntimeException('Cannot read fixture for ' . $url);
+    }
+    return $contents;
+  }
+
+}


### PR DESCRIPTION
Closes #135. Adds AbsoluteUrlToInternal on body for all three migrations, wires field_route via fns_route_slug_lookup for skate events, extends fns_migrate_install() to attach body to news/page bundles, and adds MigrateExecuteTestBase kernel tests for all three. 66/66 fns_migrate tests pass.