### PR TITLE
Fix private filesystem and fns_page migration 404

### DIFF
--- a/web/modules/custom/fns_migrate/migrations/fns_page.yml
+++ b/web/modules/custom/fns_migrate/migrations/fns_page.yml
@@ -4,10 +4,14 @@ migration_group: fns
 source:
   plugin: fns_page_html
   base_url: 'https://fridaynightskate.com'
-  index_path: /pages
-  page_query: page
-  first_page: 1
-  max_pages: 50
+  slugs:
+    - about
+    - contact
+    - faq
+    - privacy
+    - safety
+    - specials
+    - sponsors
 process:
   title: title
   field_legacy_id: id

--- a/web/modules/custom/fns_migrate/src/Plugin/migrate/source/FnsPageHtml.php
+++ b/web/modules/custom/fns_migrate/src/Plugin/migrate/source/FnsPageHtml.php
@@ -25,7 +25,11 @@ use Symfony\Component\DomCrawler\Crawler;
  * Configuration keys (all optional, sensible defaults):
  *   base_url:    Origin of the legacy site. Default
  *                'https://fridaynightskate.com'.
- *   index_path:  Path of the paginated index. Default '/pages'.
+ *   slugs:       Optional explicit list of page slugs to fetch. When
+ *                provided the paginated index is skipped entirely and each
+ *                slug is fetched as `{base_url}/pages/{slug}`.
+ *   index_path:  Path of the paginated index. Default '/pages'. Ignored
+ *                when `slugs` is provided.
  *   page_query:  Query parameter used for pagination. Default 'page'.
  *   first_page:  First page number. Default 1.
  *   max_pages:   Hard cap on pages to walk (safety net). Default 50.
@@ -68,6 +72,13 @@ class FnsPageHtml extends SourcePluginBase implements ContainerFactoryPluginInte
   protected int $maxPages;
 
   /**
+   * Explicit slug list (bypasses index crawl when non-empty).
+   *
+   * @var string[]
+   */
+  protected array $slugs;
+
+  /**
    * Constructs a FnsPageHtml source plugin.
    *
    * @param array $configuration
@@ -94,6 +105,7 @@ class FnsPageHtml extends SourcePluginBase implements ContainerFactoryPluginInte
     $this->pageQuery = (string) ($configuration['page_query'] ?? self::DEFAULT_PAGE_QUERY);
     $this->firstPage = (int) ($configuration['first_page'] ?? 1);
     $this->maxPages = (int) ($configuration['max_pages'] ?? self::DEFAULT_MAX_PAGES);
+    $this->slugs = (array) ($configuration['slugs'] ?? []);
   }
 
   /**
@@ -145,11 +157,17 @@ class FnsPageHtml extends SourcePluginBase implements ContainerFactoryPluginInte
   /**
    * {@inheritdoc}
    *
-   * Walks the paginated index, then yields one parsed row per detail page.
+   * When `slugs` is configured, fetches each slug directly without crawling
+   * the paginated index. Otherwise walks the paginated index as before.
    * Every HTTP fetch goes through the cached {@see FnsHttpClient}, so a second
    * run replays disk-backed responses and never hits the network.
    */
   protected function initializeIterator(): \Iterator {
+    if ($this->slugs !== []) {
+      yield from $this->iterateSlugs();
+      return;
+    }
+
     $seen = [];
     $page = $this->firstPage;
     $walked = 0;
@@ -185,6 +203,21 @@ class FnsPageHtml extends SourcePluginBase implements ContainerFactoryPluginInte
 
       $page++;
       $walked++;
+    }
+  }
+
+  /**
+   * Iterate over the explicit slug list, fetching each detail page directly.
+   */
+  protected function iterateSlugs(): \Iterator {
+    foreach ($this->slugs as $slug) {
+      $slug = (string) $slug;
+      $detailUrl = $this->baseUrl . '/pages/' . ltrim($slug, '/');
+      $detailHtml = $this->httpClient->fetch($detailUrl, 'pages', $slug);
+      $row = $this->parseDetail($detailUrl, $slug, $detailHtml);
+      if ($row !== NULL) {
+        yield $row;
+      }
     }
   }
 

--- a/web/modules/custom/fns_migrate/tests/src/Kernel/FnsPageMigrateTest.php
+++ b/web/modules/custom/fns_migrate/tests/src/Kernel/FnsPageMigrateTest.php
@@ -65,8 +65,6 @@ class FnsPageMigrateTest extends MigrateTestBase {
     $fixtures = __DIR__ . '/../../fixtures/pages';
     $base = 'https://legacy.test';
     $stub = new FixturePageExecuteHttpClient([
-      $base . '/pages'          => $fixtures . '/index-1.html',
-      $base . '/pages?page=2'   => $fixtures . '/index-2.html',
       $base . '/pages/about'        => $fixtures . '/about.html',
       $base . '/pages/safety-guide' => $fixtures . '/safety-guide.html',
     ]);
@@ -80,6 +78,7 @@ class FnsPageMigrateTest extends MigrateTestBase {
     $migration = $this->getMigration('fns_page');
     $source = $migration->getSourceConfiguration();
     $source['base_url'] = 'https://legacy.test';
+    $source['slugs'] = ['about', 'safety-guide'];
     $migration->set('source', $source);
     $this->executeMigration($migration);
 

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -894,7 +894,6 @@ if (getenv('IS_DDEV_PROJECT') == 'true' && file_exists(__DIR__ . '/settings.ddev
  *
  * Keep this code block at the end of this file to take full effect.
  */
-#
-# if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
-#   include $app_root . '/' . $site_path . '/settings.local.php';
-# }
+if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
+  include $app_root . '/' . $site_path . '/settings.local.php';
+}


### PR DESCRIPTION
Fixes two runtime errors seen in `ddev drush migrate:status --group=fns`:\n\n1. **Private filesystem not configured** — `settings.local.php` include was commented out in `settings.php`, so `file_private_path` was never applied. All fns_migrate source plugins cache responses under `private://fns_migrate_cache/` — without a configured private path every migration reported a directory permissions error. Fixed by uncommenting the include block.\n\n2. **fns_page 404** — the live site has no paginated `/pages` index (returns 404). Pages live at `/pages/{slug}` directly. Added a `slugs` config key to `FnsPageHtml` that bypasses the index crawl and fetches each slug directly. Updated `fns_page.yml` with the 7 known slugs. Updated `FnsPageMigrateTest` accordingly.\n\nAll 66 fns_migrate tests pass (589 assertions).