### PR TITLE
Fix fns_skate_event: use ids config to bypass broken index crawl

### DIFF
--- a/web/modules/custom/fns_migrate/migrations/fns_skate_event.yml
+++ b/web/modules/custom/fns_migrate/migrations/fns_skate_event.yml
@@ -4,10 +4,24 @@ migration_group: fns
 source:
   plugin: fns_skate_event_html
   base_url: 'https://fridaynightskate.com'
-  index_path: /skate
-  page_query: page
-  first_page: 1
-  max_pages: 50
+  ids:
+    - 1
+    - 2
+    - 3
+    - 5
+    - 8
+    - 10
+    - 11
+    - 12
+    - 13
+    - 14
+    - 15
+    - 16
+    - 17
+    - 18
+    - 19
+    - 20
+    - 21
 process:
   title: title
   field_legacy_id: id

--- a/web/modules/custom/fns_migrate/src/Plugin/migrate/source/FnsSkateEventHtml.php
+++ b/web/modules/custom/fns_migrate/src/Plugin/migrate/source/FnsSkateEventHtml.php
@@ -29,7 +29,11 @@ use Symfony\Component\DomCrawler\Crawler;
  * Configuration keys (all optional, sensible defaults):
  *   base_url:    Origin of the legacy site. Default
  *                'https://fridaynightskate.com'.
- *   index_path:  Path of the paginated index. Default '/skate'.
+ *   ids:         Optional explicit list of numeric event IDs to fetch. When
+ *                provided the paginated index is skipped entirely and each
+ *                ID is fetched as `{base_url}/skate/{id}`.
+ *   index_path:  Path of the paginated index. Default '/skate'. Ignored
+ *                when `ids` is provided.
  *   page_query:  Query parameter used for pagination. Default 'page'.
  *   first_page:  First page number. Default 1.
  *   max_pages:   Hard cap on pages to walk (safety net). Default 50.
@@ -72,6 +76,13 @@ class FnsSkateEventHtml extends SourcePluginBase implements ContainerFactoryPlug
   protected int $maxPages;
 
   /**
+   * Explicit ID list (bypasses index crawl when non-empty).
+   *
+   * @var int[]
+   */
+  protected array $ids;
+
+  /**
    * Constructs a FnsSkateEventHtml source plugin.
    *
    * @param array $configuration
@@ -98,6 +109,7 @@ class FnsSkateEventHtml extends SourcePluginBase implements ContainerFactoryPlug
     $this->pageQuery = (string) ($configuration['page_query'] ?? self::DEFAULT_PAGE_QUERY);
     $this->firstPage = (int) ($configuration['first_page'] ?? 1);
     $this->maxPages = (int) ($configuration['max_pages'] ?? self::DEFAULT_MAX_PAGES);
+    $this->ids = array_map('intval', (array) ($configuration['ids'] ?? []));
   }
 
   /**
@@ -158,6 +170,11 @@ class FnsSkateEventHtml extends SourcePluginBase implements ContainerFactoryPlug
    * See issues-blogger-content-migration.md for rationale.
    */
   protected function initializeIterator(): \Iterator {
+    if ($this->ids !== []) {
+      yield from $this->iterateIds();
+      return;
+    }
+
     $seen = [];
     $page = $this->firstPage;
     $walked = 0;
@@ -204,6 +221,24 @@ class FnsSkateEventHtml extends SourcePluginBase implements ContainerFactoryPlug
 
       $page++;
       $walked++;
+    }
+  }
+
+  /**
+   * Iterate over the explicit ID list, fetching each detail page directly.
+   */
+  protected function iterateIds(): \Iterator {
+    foreach ($this->ids as $id) {
+      $slug = (string) $id;
+      $detailUrl = $this->baseUrl . '/skate/' . $slug;
+      $detailHtml = $this->httpClient->fetch($detailUrl, 'skates', $slug);
+      if ($this->isLiveTrackerPage($detailHtml)) {
+        continue;
+      }
+      $row = $this->parseDetail($detailUrl, $slug, $detailHtml);
+      if ($row !== NULL) {
+        yield $row;
+      }
     }
   }
 

--- a/web/modules/custom/fns_migrate/tests/src/Kernel/FnsSkateEventMigrateTest.php
+++ b/web/modules/custom/fns_migrate/tests/src/Kernel/FnsSkateEventMigrateTest.php
@@ -65,10 +65,8 @@ class FnsSkateEventMigrateTest extends MigrateTestBase {
     $fixtures = __DIR__ . '/../../fixtures/skates';
     $base = 'https://legacy.test';
     $stub = new FixtureSkateEventHttpClient([
-      $base . '/skate'          => $fixtures . '/index-1.html',
-      $base . '/skate?page=2'   => $fixtures . '/index-2.html',
-      $base . '/skate/friday-night-canal-run'   => $fixtures . '/friday-night-canal-run.html',
-      $base . '/skate/old-town-evening-skate'   => $fixtures . '/old-town-evening-skate.html',
+      $base . '/skate/1' => $fixtures . '/friday-night-canal-run.html',
+      $base . '/skate/2' => $fixtures . '/old-town-evening-skate.html',
     ]);
     $this->container->set('fns_migrate.http_client', $stub);
   }
@@ -80,6 +78,7 @@ class FnsSkateEventMigrateTest extends MigrateTestBase {
     $migration = $this->getMigration('fns_skate_event');
     $source = $migration->getSourceConfiguration();
     $source['base_url'] = 'https://legacy.test';
+    $source['ids'] = [1, 2];
     $migration->set('source', $source);
     $this->executeMigration($migration);
 
@@ -88,7 +87,7 @@ class FnsSkateEventMigrateTest extends MigrateTestBase {
       ->accessCheck(FALSE)
       ->execute();
 
-    // Two unique slugs from the fixtures (duplicate + /live URL are skipped).
+    // Two events fetched directly by ID from fixtures.
     $this->assertCount(2, $nids, 'Two event nodes created.');
 
     $nodes = Node::loadMultiple($nids);


### PR DESCRIPTION
The live site `/skate` page shows only the latest event — not a paginated list. Events are listed at `/agenda` as `/skate/{id}` with numeric IDs (not slugs).\n\n## Changes\n- **`FnsSkateEventHtml.php`**: Added `ids` config key; when provided, bypasses the index crawl and fetches each event directly as `{base_url}/skate/{id}`.\n- **`fns_skate_event.yml`**: Replaced index crawl config with the 17 known event IDs (1–3, 5, 8, 10–21).\n- **`FnsSkateEventMigrateTest.php`**: Updated to use `ids` config and direct URL fixtures.\n\n## Verification\n- All 66 `fns_migrate` tests pass (589 assertions).\n- `ddev drush migrate:status --group=fns` shows 17 total for `fns_skate_event`.